### PR TITLE
feat(mds): add FoundationDB KV backend

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,27 @@ jobs:
           rustup default stable
           rustc --version
           cargo --version
+
+      - name: Install FoundationDB client library
+        run: |
+          # curvine-mds links libfdb_c unconditionally (foundationdb crate,
+          # fdb-7_3). The client rpm ships libfdb_c.so needed at link time;
+          # embedded-fdb-include already provides the headers at build time, so
+          # only the client library is required here.
+          set -euo pipefail
+          FDB_VERSION=7.3.77
+          curl -fsSL -o /tmp/foundationdb-clients.rpm \
+            "https://github.com/apple/foundationdb/releases/download/${FDB_VERSION}/foundationdb-clients-${FDB_VERSION}-1.el7.x86_64.rpm"
+          rpm -i --nodeps /tmp/foundationdb-clients.rpm
+          # The rpm installs libfdb_c.so under /usr/lib; also expose it under
+          # /usr/lib64 (Rocky's default 64-bit lib dir) so the linker finds it
+          # regardless of its default search paths.
+          if [ -f /usr/lib/libfdb_c.so ] && [ ! -e /usr/lib64/libfdb_c.so ]; then
+            ln -s /usr/lib/libfdb_c.so /usr/lib64/libfdb_c.so
+          fi
+          echo "/usr/lib" > /etc/ld.so.conf.d/foundationdb.conf
+          ldconfig
+          ldconfig -p | grep libfdb_c || (echo "libfdb_c not registered" && exit 1)
       
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,8 +61,12 @@ jobs:
           # only the client library is required here.
           set -euo pipefail
           FDB_VERSION=7.3.77
+          # Pinned SHA256 of the official release asset (supply-chain safety):
+          # verify the download before installing.
+          FDB_CLIENTS_SHA256=9255a4730655ac1a8461d8da5148a9d87c8978944188477f5b745318bb6d40ba
           curl -fsSL -o /tmp/foundationdb-clients.rpm \
             "https://github.com/apple/foundationdb/releases/download/${FDB_VERSION}/foundationdb-clients-${FDB_VERSION}-1.el7.x86_64.rpm"
+          echo "${FDB_CLIENTS_SHA256}  /tmp/foundationdb-clients.rpm" | sha256sum -c -
           rpm -i --nodeps /tmp/foundationdb-clients.rpm
           # The rpm installs libfdb_c.so under /usr/lib; also expose it under
           # /usr/lib64 (Rocky's default 64-bit lib dir) so the linker finds it

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1197,6 +1197,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
+dependencies = [
+ "bitflags 2.10.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "log",
+ "prettyplease 0.2.37",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2544,6 +2564,7 @@ dependencies = [
  "curvine-metrics",
  "curvine-runtime",
  "fastrand 1.9.0",
+ "foundationdb",
  "log",
  "once_cell",
  "thiserror 1.0.69",
@@ -4192,6 +4213,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "foundationdb"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "514aeffe12bbcf2f64a746793cc1c2602006c705d3fc6285df024303d008cccf"
+dependencies = [
+ "async-recursion",
+ "async-trait",
+ "foundationdb-gen",
+ "foundationdb-macros",
+ "foundationdb-sys",
+ "foundationdb-tuple",
+ "futures",
+ "memchr",
+ "rand 0.8.5",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "static_assertions",
+]
+
+[[package]]
+name = "foundationdb-gen"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef9d854866df33e1f4099769e2b9fa8bf8cf3bca707029ae6298d0e61bcae358"
+dependencies = [
+ "xml-rs",
+]
+
+[[package]]
+name = "foundationdb-macros"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4ca5370149145ec3741cd7e82832f17f893b9421ee4e484d9511c6702bd9911"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "try_map",
+]
+
+[[package]]
+name = "foundationdb-sys"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bae14dba30b8dcc4905a9189ebb18bc9db9744ef0ad8f2b94ef00d21e176964"
+dependencies = [
+ "bindgen 0.70.1",
+ "libc",
+]
+
+[[package]]
+name = "foundationdb-tuple"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1832c1fbe592de718893f7c3b48179a47757f8974d1498fece997454c2b0fa"
+dependencies = [
+ "memchr",
+ "uuid",
 ]
 
 [[package]]
@@ -6293,7 +6376,7 @@ version = "0.16.0+8.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce3d60bc059831dc1c83903fb45c103f75db65c5a7bf22272764d9cc683e348c"
 dependencies = [
- "bindgen",
+ "bindgen 0.69.5",
  "bzip2-sys",
  "cc",
  "glob",
@@ -6781,7 +6864,7 @@ checksum = "478b0ff3f7d67b79da2b96f56f334431aef65e15ba4b29dd74a4236e29582bdc"
 dependencies = [
  "base64 0.21.7",
  "bigdecimal",
- "bindgen",
+ "bindgen 0.69.5",
  "bitflags 2.10.0",
  "bitvec",
  "btoi",
@@ -9464,6 +9547,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10905,6 +10998,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "try_map"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb1626d07cb5c1bb2cf17d94c0be4852e8a7c02b041acec9a8c5bdda99f9d580"
+
+[[package]]
 name = "twox-hash"
 version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11976,6 +12075,12 @@ checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
 ]
+
+[[package]]
+name = "xml-rs"
+version = "0.8.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e450f9b2ed1dff33c94c12589a87338689467b9c4f5d8a5710bd09a847d2c8a7"
 
 [[package]]
 name = "xmlparser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -237,6 +237,7 @@ percent-encoding = "2.3.1"
 url = "2.2.2"
 async-trait = "0.1.76"
 etcd-client = { version = "0.19", default-features = false }
+foundationdb = { version = "0.9", default-features = false }
 fastrand = "1.9.0"
 num_cpus = "1.16.0"
 slog = "2.7.0"

--- a/crates/common/curvine-config/src/lib.rs
+++ b/crates/common/curvine-config/src/lib.rs
@@ -50,7 +50,7 @@ mod client_conf;
 pub use self::client_conf::{ClientConf, ClientConfCliOverrides};
 
 mod fuse_conf;
-pub use self::fuse_conf::FuseConf;
+pub use self::fuse_conf::{FuseConf, FuseConfCliOverrides};
 
 mod job_conf;
 pub use self::job_conf::JobConf;
@@ -67,6 +67,9 @@ pub use pipeline::{ConfigLoader, DiscoveredPath};
 
 /// Unified validation framework (per-section validate + unknown-key audit).
 pub mod validation;
+
+/// Hot-reload extension points (no watcher/RPC wired yet — see module docs).
+pub mod reload;
 
 impl curvine_model::ClientConfDefaults for ClientConf {
     fn replicas(&self) -> i32 {

--- a/crates/common/curvine-config/src/lib.rs
+++ b/crates/common/curvine-config/src/lib.rs
@@ -29,7 +29,7 @@ mod master_conf;
 pub use self::master_conf::MasterConf;
 
 mod mds_conf;
-pub use self::mds_conf::MdsConf;
+pub use self::mds_conf::{KvBackendType, MdsConf};
 
 mod compatibility_conf;
 pub use self::compatibility_conf::CompatibilityConf;
@@ -50,7 +50,7 @@ mod client_conf;
 pub use self::client_conf::{ClientConf, ClientConfCliOverrides};
 
 mod fuse_conf;
-pub use self::fuse_conf::{FuseConf, FuseConfCliOverrides};
+pub use self::fuse_conf::FuseConf;
 
 mod job_conf;
 pub use self::job_conf::JobConf;
@@ -67,9 +67,6 @@ pub use pipeline::{ConfigLoader, DiscoveredPath};
 
 /// Unified validation framework (per-section validate + unknown-key audit).
 pub mod validation;
-
-/// Hot-reload extension points (no watcher/RPC wired yet — see module docs).
-pub mod reload;
 
 impl curvine_model::ClientConfDefaults for ClientConf {
     fn replicas(&self) -> i32 {

--- a/crates/common/curvine-config/src/mds_conf.rs
+++ b/crates/common/curvine-config/src/mds_conf.rs
@@ -2,6 +2,14 @@ use curvine_core_error::{err_box, CommonResult};
 use curvine_runtime::common::LogConf;
 use serde::{Deserialize, Serialize};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum KvBackendType {
+    Memory,
+    #[default]
+    Fdb,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct MdsConf {
@@ -11,15 +19,30 @@ pub struct MdsConf {
     pub web_port: u16,
     pub io_threads: usize,
     pub worker_threads: usize,
+    pub kv_backend: KvBackendType,
+    /// Path to the FoundationDB cluster file (the same file `fdbcli -C <path>`
+    /// accepts). Required when `kv_backend = "fdb"`; the MDS opens FDB directly
+    /// from this path.
+    pub fdb_cluster_file: String,
+    /// Per-transaction timeout (ms) applied to every FDB transaction.
+    ///
+    /// Leave it at the default unless you really know FoundationDB: it bounds
+    /// how long an operation waits on a stuck/unreachable cluster before
+    /// failing fast. Too small causes spurious timeouts under normal load; too
+    /// large lets a wedged cluster stall requests. Do NOT tune it by hand
+    /// without a clear reason.
+    pub fdb_txn_timeout_ms: i32,
     pub log: LogConf,
 }
 
 impl MdsConf {
     pub const DEFAULT_RPC_PORT: u16 = 8998;
     pub const DEFAULT_WEB_PORT: u16 = 9004;
+    pub const DEFAULT_FDB_TXN_TIMEOUT_MS: i32 = 5_000;
 
     pub fn init(&mut self) -> CommonResult<()> {
         self.hostname = self.hostname.trim().to_string();
+        self.fdb_cluster_file = self.fdb_cluster_file.trim().to_string();
         if self.hostname.is_empty() {
             return err_box!("mds.hostname must not be empty");
         }
@@ -38,6 +61,12 @@ impl MdsConf {
         if self.worker_threads == 0 {
             return err_box!("mds.worker_threads must be greater than zero");
         }
+        if self.fdb_txn_timeout_ms <= 0 {
+            return err_box!("mds.fdb_txn_timeout_ms must be greater than zero");
+        }
+        if self.kv_backend == KvBackendType::Fdb && self.fdb_cluster_file.is_empty() {
+            return err_box!("mds.kv_backend=fdb requires a non-empty mds.fdb_cluster_file");
+        }
         Ok(())
     }
 }
@@ -51,6 +80,9 @@ impl Default for MdsConf {
             web_port: Self::DEFAULT_WEB_PORT,
             io_threads: 4,
             worker_threads: 8,
+            kv_backend: KvBackendType::default(),
+            fdb_cluster_file: "/etc/foundationdb/fdb.cluster".to_string(),
+            fdb_txn_timeout_ms: Self::DEFAULT_FDB_TXN_TIMEOUT_MS,
             log: LogConf {
                 file_name: "mds.log".to_string(),
                 ..Default::default()
@@ -65,12 +97,17 @@ mod tests {
 
     #[test]
     fn defaults_are_disabled_and_valid() {
+        // Default kv_backend is fdb with the standard cluster-file path, so the
+        // bare default is valid.
         let mut conf = MdsConf::default();
         conf.init().unwrap();
 
         assert!(!conf.enabled);
         assert_eq!(conf.rpc_port, MdsConf::DEFAULT_RPC_PORT);
         assert_eq!(conf.web_port, MdsConf::DEFAULT_WEB_PORT);
+        assert_eq!(conf.kv_backend, KvBackendType::Fdb);
+        assert_eq!(conf.fdb_cluster_file, "/etc/foundationdb/fdb.cluster");
+        assert_eq!(conf.fdb_txn_timeout_ms, MdsConf::DEFAULT_FDB_TXN_TIMEOUT_MS);
         assert_eq!(conf.log.file_name, "mds.log");
     }
 
@@ -86,6 +123,63 @@ mod tests {
             web_port: MdsConf::DEFAULT_RPC_PORT,
             ..Default::default()
         };
+        assert!(conf.init().is_err());
+    }
+
+    #[test]
+    fn rejects_invalid_fdb_timeout() {
+        let mut conf = MdsConf {
+            fdb_txn_timeout_ms: 0,
+            ..Default::default()
+        };
+        assert!(conf.init().is_err());
+    }
+
+    #[test]
+    fn missing_fdb_timeout_uses_default() {
+        let conf: MdsConf = toml::from_str(
+            r#"
+                enabled = true
+                fdb_cluster_file = "/tmp/fdb.cluster"
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(conf.fdb_txn_timeout_ms, 5_000);
+    }
+
+    #[test]
+    fn parses_kv_backend() {
+        let memory: MdsConf = toml::from_str(r#"kv_backend = "memory""#).unwrap();
+        assert_eq!(memory.kv_backend, KvBackendType::Memory);
+
+        let fdb: MdsConf = toml::from_str(r#"kv_backend = "fdb""#).unwrap();
+        assert_eq!(fdb.kv_backend, KvBackendType::Fdb);
+    }
+
+    #[test]
+    fn fdb_accepts_cluster_file() {
+        let mut conf: MdsConf = toml::from_str(
+            r#"
+                enabled = true
+                kv_backend = "fdb"
+                fdb_cluster_file = "/etc/foundationdb/fdb.cluster"
+            "#,
+        )
+        .unwrap();
+        conf.init().unwrap();
+        assert_eq!(conf.fdb_cluster_file, "/etc/foundationdb/fdb.cluster");
+    }
+
+    #[test]
+    fn fdb_requires_cluster_file() {
+        let mut conf: MdsConf = toml::from_str(
+            r#"
+                kv_backend = "fdb"
+                fdb_cluster_file = ""
+            "#,
+        )
+        .unwrap();
         assert!(conf.init().is_err());
     }
 }

--- a/curvine-docker/deploy/example/conf/curvine-cluster.toml
+++ b/curvine-docker/deploy/example/conf/curvine-cluster.toml
@@ -70,6 +70,18 @@ journal_dir = "./data/journal"
 rpc_port = 8997
 web_port = 9000
 dir_reserved = "10GB"
+# Strict physical free-space floor for Curvine write admission. The worker
+# reports only bytes above this floor, so both new blocks and FileLayout rewrite
+# staging copies are rejected if their full reservation would cross it. Existing
+# committed data remains readable, but files on a low-space worker may be
+# temporarily non-writable. This protects shared-device space for other apps.
+#
+# Rewrites do not bypass the floor: FileLayout keeps committed + staging copies
+# concurrently, and an expanding rewrite reserves the full target block size
+# (for example, rewriting a 10GB block with a 20GB target may need about 30GB at
+# peak). 0.0 disables (default). Range [0.0, 1.0); 0.1 protects 10%.
+# Another app can still consume space after the worker samples the device.
+# free_ratio = 0.1
 data_dir = [
     "[SSD]/data/data1",
 ]

--- a/curvine-docker/deploy/example/conf/curvine-cluster.toml
+++ b/curvine-docker/deploy/example/conf/curvine-cluster.toml
@@ -48,6 +48,13 @@ log = { level = "info", log_dir = "./logs", file_name = "master.log" }
 enabled = false
 rpc_port = 8998
 web_port = 9004
+# KV storage backend. Supported values: "fdb" and "memory".
+# Use "fdb" for production deployments; "memory" is only intended for tests
+# and loses all metadata when the MDS process exits.
+kv_backend = "fdb"
+# Path to the FoundationDB cluster file (the same file `fdbcli -C <path>`
+# accepts). Required when kv_backend = "fdb".
+fdb_cluster_file = "/etc/foundationdb/fdb.cluster"
 log = { level = "info", log_dir = "./logs", file_name = "mds.log" }
 
 [journal]
@@ -63,18 +70,6 @@ journal_dir = "./data/journal"
 rpc_port = 8997
 web_port = 9000
 dir_reserved = "10GB"
-# Strict physical free-space floor for Curvine write admission. The worker
-# reports only bytes above this floor, so both new blocks and FileLayout rewrite
-# staging copies are rejected if their full reservation would cross it. Existing
-# committed data remains readable, but files on a low-space worker may be
-# temporarily non-writable. This protects shared-device space for other apps.
-#
-# Rewrites do not bypass the floor: FileLayout keeps committed + staging copies
-# concurrently, and an expanding rewrite reserves the full target block size
-# (for example, rewriting a 10GB block with a 20GB target may need about 30GB at
-# peak). 0.0 disables (default). Range [0.0, 1.0); 0.1 protects 10%.
-# Another app can still consume space after the worker samples the device.
-# free_ratio = 0.1
 data_dir = [
     "[SSD]/data/data1",
 ]

--- a/curvine-mds/Cargo.toml
+++ b/curvine-mds/Cargo.toml
@@ -11,6 +11,7 @@ curvine-metrics = { workspace = true }
 curvine-runtime = { workspace = true }
 async-trait = { workspace = true }
 fastrand = { workspace = true }
+foundationdb = { workspace = true, features = ["fdb-7_3", "embedded-fdb-include"] }
 log = { workspace = true }
 once_cell = { workspace = true }
 thiserror = { workspace = true }

--- a/curvine-mds/src/kv/contract_tests.rs
+++ b/curvine-mds/src/kv/contract_tests.rs
@@ -325,7 +325,10 @@ async fn reads_observe_begin_snapshot(be: Arc<dyn KvBackend>, p: &[u8]) {
 
 fn error_classification() {
     assert!(KvError::Conflict.is_retryable());
-    assert!(KvError::Timeout.is_retryable());
+    assert!(KvError::TransientUnavailable("down".into()).is_retryable());
+    // DeadlineExceeded is NOT retryable: the per-txn deadline (the caller's wait
+    // budget) is exhausted, so it must surface rather than re-run.
+    assert!(!KvError::DeadlineExceeded.is_retryable());
     // MaybeCommitted is NOT retryable: the write may already have applied.
     assert!(!KvError::MaybeCommitted.is_retryable());
     assert!(!KvError::Aborted("a".into()).is_retryable());
@@ -576,12 +579,15 @@ async fn fdb_unreachable_cluster_does_not_hang() {
         Err(_elapsed) => panic!("begin() hung on an unreachable cluster (blocked >30s)"),
         Ok(Ok(_txn)) => panic!("begin() unexpectedly succeeded against an unreachable cluster"),
         Ok(Err(err)) => {
-            // Fail-fast surfaced as a retryable error (Timeout, or another
-            // transient class). It must NOT be a silent hang, which is all this
-            // criterion requires.
+            // Fail-fast surfaced as a bounded error instead of a silent hang —
+            // which is all this criterion requires. The exact class depends on
+            // how FDB reports the unreachable cluster: `DeadlineExceeded` if the
+            // per-txn deadline is hit, or `TransientUnavailable` for a
+            // connection-level failure. Both are acceptable; a hang (handled
+            // above) is not.
             assert!(
-                err.is_retryable(),
-                "expected a fail-fast retryable error, got {err:?}"
+                matches!(err, KvError::DeadlineExceeded | KvError::TransientUnavailable(_)),
+                "expected a bounded fail-fast error (DeadlineExceeded/TransientUnavailable), got {err:?}"
             );
         }
     }

--- a/curvine-mds/src/kv/contract_tests.rs
+++ b/curvine-mds/src/kv/contract_tests.rs
@@ -82,9 +82,20 @@ async fn arbitrary_bytes_round_trip(be: Arc<dyn KvBackend>, p: &[u8]) {
 }
 
 async fn distinct_invalid_utf8_keys_remain_distinct(be: Arc<dyn KvBackend>, p: &[u8]) {
-    let key_1 = k(p, &[b'f', b'o', 0x80]);
-    let key_2 = k(p, &[b'f', b'o', 0x81]);
+    // Two distinct invalid-UTF8 byte suffixes that collapse to the SAME lossy
+    // string (0x80 and 0x81 both render as the replacement char U+FFFD). The
+    // backend must key on raw bytes, so they must stay distinct despite the
+    // lossy collision.
+    let suffix_1 = [b'f', b'o', 0x80];
+    let suffix_2 = [b'f', b'o', 0x81];
+    assert_eq!(
+        String::from_utf8_lossy(&suffix_1),
+        String::from_utf8_lossy(&suffix_2),
+        "test premise: the two keys must share a lossy string representation"
+    );
 
+    let key_1 = k(p, &suffix_1);
+    let key_2 = k(p, &suffix_2);
     assert_ne!(key_1, key_2);
 
     be.put(&key_1, b"value-1").await.unwrap();

--- a/curvine-mds/src/kv/contract_tests.rs
+++ b/curvine-mds/src/kv/contract_tests.rs
@@ -1,9 +1,10 @@
 //! Backend-agnostic KV contract tests.
 //!
 //! Every assertion here is expressed against the [`KvBackend`] trait, never a
-//! concrete type, so the FoundationDB backend (a later step) can run the exact
-//! same suite by supplying its own factory. The memory backend is wired up at
-//! the bottom of this file via [`run_contract`].
+//! concrete type, so any backend can run the exact same suite by supplying its
+//! own factory to [`run_contract`]. The memory backend runs it unconditionally;
+//! the FoundationDB backend runs it against a real cluster when
+//! `CURVINE_MDS_FDB_CLUSTER` is set (see the fdb bindings at the bottom).
 
 use crate::kv::backend::{run_txn, KvBackend, DEFAULT_MAX_RETRIES};
 use crate::kv::error::KvError;
@@ -14,42 +15,55 @@ fn b(s: &str) -> Vec<u8> {
     s.as_bytes().to_vec()
 }
 
+/// Builds a test key `prefix || name`. Values never need prefixing; only keys
+/// do, so that the FDB backend (which runs against a SHARED real cluster) gets
+/// an isolated keyspace per run. The memory backend passes an empty prefix.
+fn k(prefix: &[u8], name: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(prefix.len() + name.len());
+    out.extend_from_slice(prefix);
+    out.extend_from_slice(name);
+    out
+}
+
 // ----- point operations -----
 
-async fn point_get_put_delete(be: Arc<dyn KvBackend>) {
-    assert_eq!(be.get(&b("k")).await.unwrap(), None);
+async fn point_get_put_delete(be: Arc<dyn KvBackend>, p: &[u8]) {
+    assert_eq!(be.get(&k(p, b"k")).await.unwrap(), None);
 
-    be.put(&b("k"), &b("v")).await.unwrap();
-    assert_eq!(be.get(&b("k")).await.unwrap(), Some(b("v")));
+    be.put(&k(p, b"k"), &b("v")).await.unwrap();
+    assert_eq!(be.get(&k(p, b"k")).await.unwrap(), Some(b("v")));
 
-    be.put(&b("k"), &b("v2")).await.unwrap();
-    assert_eq!(be.get(&b("k")).await.unwrap(), Some(b("v2")));
+    be.put(&k(p, b"k"), &b("v2")).await.unwrap();
+    assert_eq!(be.get(&k(p, b"k")).await.unwrap(), Some(b("v2")));
 
-    be.delete(&b("k")).await.unwrap();
-    assert_eq!(be.get(&b("k")).await.unwrap(), None);
+    be.delete(&k(p, b"k")).await.unwrap();
+    assert_eq!(be.get(&k(p, b"k")).await.unwrap(), None);
     // delete of an absent key is a no-op success.
-    be.delete(&b("k")).await.unwrap();
+    be.delete(&k(p, b"k")).await.unwrap();
 }
 
 // ----- batch operations -----
 
-async fn batch_get_delete(be: Arc<dyn KvBackend>) {
-    be.put(&b("a"), &b("1")).await.unwrap();
-    be.put(&b("c"), &b("3")).await.unwrap();
+async fn batch_get_delete(be: Arc<dyn KvBackend>, p: &[u8]) {
+    be.put(&k(p, b"a"), &b("1")).await.unwrap();
+    be.put(&k(p, b"c"), &b("3")).await.unwrap();
 
-    let got = be.multi_get(&[b("a"), b("b"), b("c")]).await.unwrap();
-    assert_eq!(got, vec![Some(b("1")), None, Some(b("3"))]);
-
-    be.batch_delete(&[b("a"), b("c"), b("missing")])
+    let got = be
+        .multi_get(&[k(p, b"a"), k(p, b"b"), k(p, b"c")])
         .await
         .unwrap();
-    let got = be.multi_get(&[b("a"), b("c")]).await.unwrap();
+    assert_eq!(got, vec![Some(b("1")), None, Some(b("3"))]);
+
+    be.batch_delete(&[k(p, b"a"), k(p, b"c"), k(p, b"missing")])
+        .await
+        .unwrap();
+    let got = be.multi_get(&[k(p, b"a"), k(p, b"c")]).await.unwrap();
     assert_eq!(got, vec![None, None]);
 }
 
 // ----- arbitrary byte compatibility -----
 
-async fn arbitrary_bytes_round_trip(be: Arc<dyn KvBackend>) {
+async fn arbitrary_bytes_round_trip(be: Arc<dyn KvBackend>, p: &[u8]) {
     let cases = [
         vec![0x80],
         vec![0xFF],
@@ -59,21 +73,19 @@ async fn arbitrary_bytes_round_trip(be: Arc<dyn KvBackend>) {
         vec![b'a', 0x00, b'b'],
     ];
 
-    for (index, key) in cases.into_iter().enumerate() {
+    for (index, name) in cases.into_iter().enumerate() {
+        let key = k(p, &name);
         let value = vec![0x00, 0xFF, index as u8, 0x80];
         be.put(&key, &value).await.unwrap();
         assert_eq!(be.get(&key).await.unwrap(), Some(value));
     }
 }
 
-async fn distinct_invalid_utf8_keys_remain_distinct(be: Arc<dyn KvBackend>) {
-    let key_1 = vec![b'f', b'o', 0x80];
-    let key_2 = vec![b'f', b'o', 0x81];
+async fn distinct_invalid_utf8_keys_remain_distinct(be: Arc<dyn KvBackend>, p: &[u8]) {
+    let key_1 = k(p, &[b'f', b'o', 0x80]);
+    let key_2 = k(p, &[b'f', b'o', 0x81]);
 
-    assert_eq!(
-        String::from_utf8_lossy(&key_1),
-        String::from_utf8_lossy(&key_2)
-    );
+    assert_ne!(key_1, key_2);
 
     be.put(&key_1, b"value-1").await.unwrap();
     be.put(&key_2, b"value-2").await.unwrap();
@@ -82,7 +94,7 @@ async fn distinct_invalid_utf8_keys_remain_distinct(be: Arc<dyn KvBackend>) {
     assert_eq!(be.get(&key_2).await.unwrap(), Some(b("value-2")));
 }
 
-async fn multilingual_utf8_round_trip(be: Arc<dyn KvBackend>) {
+async fn multilingual_utf8_round_trip(be: Arc<dyn KvBackend>, p: &[u8]) {
     let cases = [
         ("目录/文件.txt", "中文内容"),
         ("日本語/ファイル", "内容"),
@@ -91,18 +103,16 @@ async fn multilingual_utf8_round_trip(be: Arc<dyn KvBackend>) {
         ("العربية/ملف", "قيمة"),
     ];
 
-    for (key, value) in cases {
-        be.put(key.as_bytes(), value.as_bytes()).await.unwrap();
-        assert_eq!(
-            be.get(key.as_bytes()).await.unwrap(),
-            Some(value.as_bytes().to_vec())
-        );
+    for (name, value) in cases {
+        let key = k(p, name.as_bytes());
+        be.put(&key, value.as_bytes()).await.unwrap();
+        assert_eq!(be.get(&key).await.unwrap(), Some(value.as_bytes().to_vec()));
     }
 }
 
-async fn unicode_normalization_is_not_implicit(be: Arc<dyn KvBackend>) {
-    let composed = "é".as_bytes().to_vec();
-    let decomposed = "e\u{301}".as_bytes().to_vec();
+async fn unicode_normalization_is_not_implicit(be: Arc<dyn KvBackend>, p: &[u8]) {
+    let composed = k(p, "é".as_bytes());
+    let decomposed = k(p, "e\u{301}".as_bytes());
 
     assert_ne!(composed, decomposed);
     be.put(&composed, b"composed").await.unwrap();
@@ -114,11 +124,11 @@ async fn unicode_normalization_is_not_implicit(be: Arc<dyn KvBackend>) {
 
 // ----- transactional read-modify-write -----
 
-async fn txn_read_modify_write(be: Arc<dyn KvBackend>) {
-    be.put(&b("ctr"), &b("0")).await.unwrap();
+async fn txn_read_modify_write(be: Arc<dyn KvBackend>, p: &[u8]) {
+    be.put(&k(p, b"ctr"), &b("0")).await.unwrap();
 
     // Increment inside a single transaction closure via run_txn.
-    let key = b("ctr");
+    let key = k(p, b"ctr");
     let new = run_txn(be.as_ref(), DEFAULT_MAX_RETRIES, move |txn| {
         let key = key.clone();
         Box::pin(async move {
@@ -136,12 +146,12 @@ async fn txn_read_modify_write(be: Arc<dyn KvBackend>) {
     .unwrap();
 
     assert_eq!(new, 1);
-    assert_eq!(be.get(&b("ctr")).await.unwrap(), Some(b("1")));
+    assert_eq!(be.get(&k(p, b"ctr")).await.unwrap(), Some(b("1")));
 }
 
-async fn txn_atomicity_on_abort(be: Arc<dyn KvBackend>) {
+async fn txn_atomicity_on_abort(be: Arc<dyn KvBackend>, p: &[u8]) {
     // A transaction that returns an application error must apply no writes.
-    let key = b("x");
+    let key = k(p, b"x");
     let result: Result<(), KvError> = run_txn(be.as_ref(), DEFAULT_MAX_RETRIES, move |txn| {
         let key = key.clone();
         Box::pin(async move {
@@ -152,151 +162,152 @@ async fn txn_atomicity_on_abort(be: Arc<dyn KvBackend>) {
     .await;
 
     assert!(matches!(result, Err(KvError::Aborted(_))));
-    assert_eq!(be.get(&b("x")).await.unwrap(), None);
+    assert_eq!(be.get(&k(p, b"x")).await.unwrap(), None);
 }
 
 // ----- compare-and-set -----
 
-async fn compare_and_set_semantics(be: Arc<dyn KvBackend>) {
+async fn compare_and_set_semantics(be: Arc<dyn KvBackend>, p: &[u8]) {
+    let cas = k(p, b"cas");
     // CAS from absent -> value.
     assert!(be
-        .compare_and_set(&b("cas"), None, Some(&b("v1")))
+        .compare_and_set(&cas, None, Some(&b("v1")))
         .await
         .unwrap());
-    assert_eq!(be.get(&b("cas")).await.unwrap(), Some(b("v1")));
+    assert_eq!(be.get(&cas).await.unwrap(), Some(b("v1")));
 
     // CAS with wrong expected fails and does not write.
     assert!(!be
-        .compare_and_set(&b("cas"), Some(&b("WRONG")), Some(&b("v2")))
+        .compare_and_set(&cas, Some(&b("WRONG")), Some(&b("v2")))
         .await
         .unwrap());
-    assert_eq!(be.get(&b("cas")).await.unwrap(), Some(b("v1")));
+    assert_eq!(be.get(&cas).await.unwrap(), Some(b("v1")));
 
     // CAS with correct expected succeeds.
     assert!(be
-        .compare_and_set(&b("cas"), Some(&b("v1")), Some(&b("v2")))
+        .compare_and_set(&cas, Some(&b("v1")), Some(&b("v2")))
         .await
         .unwrap());
-    assert_eq!(be.get(&b("cas")).await.unwrap(), Some(b("v2")));
+    assert_eq!(be.get(&cas).await.unwrap(), Some(b("v2")));
 
     // CAS delete (new = None).
     assert!(be
-        .compare_and_set(&b("cas"), Some(&b("v2")), None)
+        .compare_and_set(&cas, Some(&b("v2")), None)
         .await
         .unwrap());
-    assert_eq!(be.get(&b("cas")).await.unwrap(), None);
+    assert_eq!(be.get(&cas).await.unwrap(), None);
 }
 
 // ----- optimistic-concurrency conflict detection -----
 
-async fn concurrent_write_conflict(be: Arc<dyn KvBackend>) {
-    be.put(&b("k"), &b("0")).await.unwrap();
+async fn concurrent_write_conflict(be: Arc<dyn KvBackend>, p: &[u8]) {
+    be.put(&k(p, b"k"), &b("0")).await.unwrap();
 
     // Open a transaction, read k, then let another writer bump k before commit.
     let mut txn = be.begin().await.unwrap();
-    let _ = txn.get(&b("k")).await.unwrap();
+    let _ = txn.get(&k(p, b"k")).await.unwrap();
 
     // Concurrent committed write to the same key.
-    be.put(&b("k"), &b("1")).await.unwrap();
+    be.put(&k(p, b"k"), &b("1")).await.unwrap();
 
     // Our transaction now writes and must fail with Conflict.
-    txn.put(&b("k"), &b("stale"));
+    txn.put(&k(p, b"k"), &b("stale"));
     let err = txn.commit().await.unwrap_err();
     assert!(matches!(err, KvError::Conflict));
     assert!(err.is_retryable());
 
     // Store reflects only the concurrent write.
-    assert_eq!(be.get(&b("k")).await.unwrap(), Some(b("1")));
+    assert_eq!(be.get(&k(p, b"k")).await.unwrap(), Some(b("1")));
 }
 
-async fn snapshot_read_does_not_conflict(be: Arc<dyn KvBackend>) {
-    be.put(&b("s"), &b("0")).await.unwrap();
-    be.put(&b("w"), &b("init")).await.unwrap();
+async fn snapshot_read_does_not_conflict(be: Arc<dyn KvBackend>, p: &[u8]) {
+    be.put(&k(p, b"s"), &b("0")).await.unwrap();
+    be.put(&k(p, b"w"), &b("init")).await.unwrap();
 
     // A transaction snapshot-reads `s` (no conflict tracking), then a
     // concurrent writer bumps `s` before we commit.
     let mut txn = be.begin().await.unwrap();
-    let seen = txn.snapshot_get(&b("s")).await.unwrap();
+    let seen = txn.snapshot_get(&k(p, b"s")).await.unwrap();
     assert_eq!(seen, Some(b("0")));
 
-    be.put(&b("s"), &b("1")).await.unwrap();
+    be.put(&k(p, b"s"), &b("1")).await.unwrap();
 
     // We write to a DIFFERENT key and commit; because `s` was read via
     // snapshot_get it is not in the conflict set, so the commit succeeds even
     // though `s` changed concurrently.
-    txn.put(&b("w"), &b("done"));
+    txn.put(&k(p, b"w"), &b("done"));
     txn.commit().await.unwrap();
 
-    assert_eq!(be.get(&b("w")).await.unwrap(), Some(b("done")));
-    assert_eq!(be.get(&b("s")).await.unwrap(), Some(b("1")));
+    assert_eq!(be.get(&k(p, b"w")).await.unwrap(), Some(b("done")));
+    assert_eq!(be.get(&k(p, b"s")).await.unwrap(), Some(b("1")));
 
     // Contrast: the same access pattern with a plain `get` MUST conflict.
-    be.put(&b("s"), &b("0")).await.unwrap();
+    be.put(&k(p, b"s"), &b("0")).await.unwrap();
     let mut txn = be.begin().await.unwrap();
-    let _ = txn.get(&b("s")).await.unwrap();
-    be.put(&b("s"), &b("2")).await.unwrap();
-    txn.put(&b("w"), &b("stale"));
+    let _ = txn.get(&k(p, b"s")).await.unwrap();
+    be.put(&k(p, b"s"), &b("2")).await.unwrap();
+    txn.put(&k(p, b"w"), &b("stale"));
     assert!(matches!(txn.commit().await, Err(KvError::Conflict)));
 }
 
 /// A concurrent delete of a read key must conflict, exactly like an overwrite
 /// (a delete is a write; the reader depended on the key's existence).
-async fn concurrent_delete_of_read_key_conflicts(be: Arc<dyn KvBackend>) {
-    be.put(&b("d"), &b("live")).await.unwrap();
+async fn concurrent_delete_of_read_key_conflicts(be: Arc<dyn KvBackend>, p: &[u8]) {
+    be.put(&k(p, b"d"), &b("live")).await.unwrap();
 
     // T1 reads d (adds it to the conflict set) but has not committed yet.
     let mut txn = be.begin().await.unwrap();
-    assert_eq!(txn.get(&b("d")).await.unwrap(), Some(b("live")));
+    assert_eq!(txn.get(&k(p, b"d")).await.unwrap(), Some(b("live")));
 
     // T2 concurrently deletes d and commits.
-    be.delete(&b("d")).await.unwrap();
+    be.delete(&k(p, b"d")).await.unwrap();
 
     // T1 writes an unrelated key and must conflict: d was changed concurrently.
-    txn.put(&b("other"), &b("x"));
+    txn.put(&k(p, b"other"), &b("x"));
     let err = txn.commit().await.unwrap_err();
     assert!(matches!(err, KvError::Conflict));
 
-    assert_eq!(be.get(&b("d")).await.unwrap(), None);
-    assert_eq!(be.get(&b("other")).await.unwrap(), None);
+    assert_eq!(be.get(&k(p, b"d")).await.unwrap(), None);
+    assert_eq!(be.get(&k(p, b"other")).await.unwrap(), None);
 }
 
 /// Two blind writers (no reads) to the same key BOTH succeed: last-writer-wins.
 /// This matches FDB, where a conflict requires a write range to intersect
 /// another txn's *read* range; validating write sets here would make the memory
 /// backend stricter than FDB.
-async fn blind_write_write_does_not_conflict(be: Arc<dyn KvBackend>) {
+async fn blind_write_write_does_not_conflict(be: Arc<dyn KvBackend>, p: &[u8]) {
     let mut t1 = be.begin().await.unwrap();
     let mut t2 = be.begin().await.unwrap();
 
-    t1.put(&b("k"), &b("t1"));
-    t2.put(&b("k"), &b("t2"));
+    t1.put(&k(p, b"k"), &b("t1"));
+    t2.put(&k(p, b"k"), &b("t2"));
 
     // Both commits succeed (no read-write conflict); the later commit wins.
     t1.commit().await.unwrap();
     t2.commit().await.unwrap();
 
-    assert_eq!(be.get(&b("k")).await.unwrap(), Some(b("t2")));
+    assert_eq!(be.get(&k(p, b"k")).await.unwrap(), Some(b("t2")));
 }
 
 /// Reads observe the begin snapshot: keys written by another txn after begin
 /// are invisible to `get` / `snapshot_get` in the older txn.
-async fn reads_observe_begin_snapshot(be: Arc<dyn KvBackend>) {
-    be.put(&b("v"), &b("v0")).await.unwrap();
+async fn reads_observe_begin_snapshot(be: Arc<dyn KvBackend>, p: &[u8]) {
+    be.put(&k(p, b"v"), &b("v0")).await.unwrap();
 
     let mut txn = be.begin().await.unwrap();
 
     // A concurrent writer changes v and creates a new key AFTER begin.
-    be.put(&b("v"), &b("v1")).await.unwrap();
-    be.put(&b("absent_key"), &b("now_here")).await.unwrap();
+    be.put(&k(p, b"v"), &b("v1")).await.unwrap();
+    be.put(&k(p, b"absent_key"), &b("now_here")).await.unwrap();
 
     // T1 still sees the begin-time snapshot.
-    assert_eq!(txn.snapshot_get(&b("v")).await.unwrap(), Some(b("v0")));
-    assert_eq!(txn.snapshot_get(&b("absent_key")).await.unwrap(), None);
+    assert_eq!(txn.snapshot_get(&k(p, b"v")).await.unwrap(), Some(b("v0")));
+    assert_eq!(txn.snapshot_get(&k(p, b"absent_key")).await.unwrap(), None);
 
     // Snapshot reads carry no conflict, so an unrelated write commits fine.
-    txn.put(&b("unrelated"), &b("ok"));
+    txn.put(&k(p, b"unrelated"), &b("ok"));
     txn.commit().await.unwrap();
-    assert_eq!(be.get(&b("unrelated")).await.unwrap(), Some(b("ok")));
+    assert_eq!(be.get(&k(p, b"unrelated")).await.unwrap(), Some(b("ok")));
 }
 
 // ----- error semantics / classification -----
@@ -311,25 +322,27 @@ fn error_classification() {
 }
 
 /// Runs the whole contract against a fresh backend produced by `factory`.
-/// PR 3 can call this with an FDB-backed factory to reuse the suite verbatim.
-async fn run_contract<F>(factory: F)
+/// `prefix` namespaces every test key so a backend sharing a physical store
+/// across runs (the FDB cluster) sees an isolated keyspace; the memory backend
+/// passes an empty prefix. Both backends reuse this suite verbatim.
+async fn run_contract<F>(prefix: &[u8], factory: F)
 where
     F: Fn() -> Arc<dyn KvBackend>,
 {
-    point_get_put_delete(factory()).await;
-    batch_get_delete(factory()).await;
-    arbitrary_bytes_round_trip(factory()).await;
-    distinct_invalid_utf8_keys_remain_distinct(factory()).await;
-    multilingual_utf8_round_trip(factory()).await;
-    unicode_normalization_is_not_implicit(factory()).await;
-    txn_read_modify_write(factory()).await;
-    txn_atomicity_on_abort(factory()).await;
-    compare_and_set_semantics(factory()).await;
-    concurrent_write_conflict(factory()).await;
-    snapshot_read_does_not_conflict(factory()).await;
-    concurrent_delete_of_read_key_conflicts(factory()).await;
-    blind_write_write_does_not_conflict(factory()).await;
-    reads_observe_begin_snapshot(factory()).await;
+    point_get_put_delete(factory(), prefix).await;
+    batch_get_delete(factory(), prefix).await;
+    arbitrary_bytes_round_trip(factory(), prefix).await;
+    distinct_invalid_utf8_keys_remain_distinct(factory(), prefix).await;
+    multilingual_utf8_round_trip(factory(), prefix).await;
+    unicode_normalization_is_not_implicit(factory(), prefix).await;
+    txn_read_modify_write(factory(), prefix).await;
+    txn_atomicity_on_abort(factory(), prefix).await;
+    compare_and_set_semantics(factory(), prefix).await;
+    concurrent_write_conflict(factory(), prefix).await;
+    snapshot_read_does_not_conflict(factory(), prefix).await;
+    concurrent_delete_of_read_key_conflicts(factory(), prefix).await;
+    blind_write_write_does_not_conflict(factory(), prefix).await;
+    reads_observe_begin_snapshot(factory(), prefix).await;
     error_classification();
 }
 
@@ -337,7 +350,8 @@ where
 
 #[tokio::test]
 async fn memory_backend_satisfies_contract() {
-    run_contract(|| Arc::new(MemoryBackend::new())).await;
+    // Memory backend starts empty each run, so no key prefix is needed.
+    run_contract(b"", || Arc::new(MemoryBackend::new())).await;
 }
 
 #[tokio::test]
@@ -468,4 +482,96 @@ async fn memory_apply_then_unknown_does_not_flip_successful_cas() {
     // Unknown result surfaced, value written exactly once.
     assert!(matches!(out, Err(KvError::MaybeCommitted)));
     assert_eq!(be.get(&b("cas")).await.unwrap(), Some(b("v1")));
+}
+
+// ===== fdb backend bindings =====
+//
+// Gated behind the `CURVINE_MDS_FDB_CLUSTER` env var. Point it at a cluster
+// file (the same one `fdbcli -C <file>` accepts). Runs the identical contract
+// suite against real FoundationDB, e.g.:
+//
+//   CURVINE_MDS_FDB_CLUSTER=/path/to/fdb.cluster \
+//     cargo test -p curvine-mds fdb_backend_satisfies_contract
+//
+// A unique per-run key prefix isolates this run's keyspace on the shared
+// cluster, so leftover keys from earlier runs never fail a fresh assertion.
+#[tokio::test]
+async fn fdb_backend_satisfies_contract() {
+    use crate::kv::fdb::FdbBackend;
+
+    let cluster_file = match std::env::var("CURVINE_MDS_FDB_CLUSTER") {
+        Ok(path) if !path.is_empty() => path,
+        _ => {
+            eprintln!(
+                "skipping fdb_backend_satisfies_contract: set CURVINE_MDS_FDB_CLUSTER \
+                 to a cluster file to enable"
+            );
+            return;
+        }
+    };
+
+    let prefix = format!(
+        "curvine-mds-test/{}/{}/",
+        std::process::id(),
+        fastrand::u64(..)
+    )
+    .into_bytes();
+
+    run_contract(&prefix, || {
+        let backend = FdbBackend::open(&cluster_file, 5_000).expect("open fdb backend");
+        Arc::new(backend)
+    })
+    .await;
+}
+
+// Acceptance criterion "FDB unavailable or shut down must not block process
+// exit": point the backend at an UNREACHABLE cluster and assert that begin()
+// fails fast (within the per-txn timeout) instead of hanging forever. An outer
+// hard deadline guards the test itself — if begin() ever blocks indefinitely,
+// the deadline fires and the test fails loudly.
+//
+// Needs no real cluster (it boots the FDB network and targets a dead address),
+// so it runs wherever libfdb_c links; it is not gated on CURVINE_MDS_FDB_CLUSTER.
+#[tokio::test]
+async fn fdb_unreachable_cluster_does_not_hang() {
+    use crate::kv::fdb::FdbBackend;
+    use std::io::Write;
+
+    // A syntactically valid cluster file whose coordinator is unreachable
+    // (127.0.0.1:1 — nothing listens there).
+    let mut path = std::env::temp_dir();
+    path.push(format!(
+        "curvine-mds-unreachable-{}-{}.cluster",
+        std::process::id(),
+        fastrand::u64(..)
+    ));
+    {
+        let mut f = std::fs::File::create(&path).expect("create cluster file");
+        f.write_all(b"deadcluster:deadid@127.0.0.1:1")
+            .expect("write cluster file");
+    }
+
+    // Short per-txn timeout so the fail-fast path is quick.
+    let backend = FdbBackend::open(&path.to_string_lossy(), 500).expect("open backend");
+
+    // Hard deadline: begin() MUST return (with an error) well before this.
+    // If it hangs, this timeout elapses and we fail — that is the regression
+    // we are guarding against.
+    let outcome = tokio::time::timeout(std::time::Duration::from_secs(30), backend.begin()).await;
+
+    let _ = std::fs::remove_file(&path);
+
+    match outcome {
+        Err(_elapsed) => panic!("begin() hung on an unreachable cluster (blocked >30s)"),
+        Ok(Ok(_txn)) => panic!("begin() unexpectedly succeeded against an unreachable cluster"),
+        Ok(Err(err)) => {
+            // Fail-fast surfaced as a retryable error (Timeout, or another
+            // transient class). It must NOT be a silent hang, which is all this
+            // criterion requires.
+            assert!(
+                err.is_retryable(),
+                "expected a fail-fast retryable error, got {err:?}"
+            );
+        }
+    }
 }

--- a/curvine-mds/src/kv/error.rs
+++ b/curvine-mds/src/kv/error.rs
@@ -5,65 +5,103 @@
 //! transactional backend (FoundationDB) depends on the caller being able to
 //! tell an optimistic-concurrency conflict (safe to retry the whole
 //! transaction) apart from a truly failed operation. `Conflict`,
-//! `MaybeCommitted`, `Timeout` and `Unavailable` must therefore never be
-//! collapsed into an opaque backend string; `run_txn` inspects
-//! [`KvError::is_retryable`] to decide whether to re-run the transaction
-//! closure.
+//! `MaybeCommitted`, `DeadlineExceeded` and `TransientUnavailable` must
+//! therefore never be collapsed into an opaque backend string; `run_txn`
+//! inspects [`KvError::is_retryable`] to decide whether to re-run the
+//! transaction closure.
 
 use thiserror::Error;
 
 /// Errors returned by any [`crate::kv::KvBackend`] / [`crate::kv::KvTransaction`]
 /// implementation. Backends map their native failures onto these variants and
 /// never leak SDK-specific types to callers.
+///
+/// Each variant documents whether `run_txn` may retry it and why; the machine
+/// version of that answer is [`KvError::is_retryable`].
 #[derive(Debug, Clone, Error)]
 pub enum KvError {
     /// Optimistic-concurrency conflict: the transaction's read/write set
-    /// clashed with a concurrent commit. The commit did NOT apply. Safe to
-    /// retry the whole transaction closure (maps to FDB `not_committed`).
+    /// clashed with a concurrent commit (maps to FDB `not_committed`, 1020).
+    ///
+    /// RETRYABLE: the commit provably did NOT apply, so re-running the whole
+    /// closure is safe. This is the only variant counted as a real conflict in
+    /// `mds_kv_txn_conflicts_total`.
     #[error("transaction conflict, retry the transaction")]
     Conflict,
 
     /// The commit result is unknown: the mutation may or may not have been
-    /// applied (maps to FDB `commit_unknown_result`). NOT retryable —
-    /// `run_txn` surfaces it to the caller, who owns the idempotency decision.
+    /// applied (maps to FDB `commit_unknown_result` / `cluster_version_changed`,
+    /// and to a COMMIT that hit its deadline).
+    ///
+    /// NOT RETRYABLE: the write may already have applied, so re-running a
+    /// non-idempotent closure would double-apply or flip a successful CAS to
+    /// `false`. `run_txn` surfaces it to the caller, who owns the idempotency
+    /// decision (e.g. a request-id dedup record).
     #[error("commit result unknown, transaction may or may not have applied")]
     MaybeCommitted,
 
-    /// The operation exceeded its deadline. Retryable.
-    #[error("operation timed out")]
-    Timeout,
+    /// The operation exceeded its per-transaction deadline (maps to FDB
+    /// `transaction_timed_out`, 1031, on a READ).
+    ///
+    /// NOT RETRYABLE: the deadline is the caller's wait budget, so exhausting it
+    /// must surface immediately rather than silently re-running and multiplying
+    /// the wait (matches FDB's own `is_retryable(1031) == false`). Distinct from
+    /// `MaybeCommitted`: a read that hit the deadline provably wrote nothing; a
+    /// commit that hit it may have applied (that path maps to `MaybeCommitted`).
+    /// Kept distinct from `Backend` so observability can tell "deadline hit"
+    /// (tune the timeout / investigate load) from a permanent error.
+    ///
+    /// Named `DeadlineExceeded`, not `Timeout`, so it does not read as a
+    /// retryable transient timeout: exhausting the budget is terminal here.
+    #[error("operation deadline exceeded")]
+    DeadlineExceeded,
 
-    /// The backend is temporarily unavailable (e.g. FDB cluster not reachable).
-    /// Retryable with backoff.
-    #[error("backend temporarily unavailable: {0}")]
-    Unavailable(String),
+    /// A transient backend condition that is worth another attempt but is NOT a
+    /// concurrency conflict. Covers everything FDB marks retryable except the
+    /// conflict itself: cluster unreachable (`connection_failed`,
+    /// `coordinators_changed`), read version too old (`transaction_too_old`),
+    /// storage lagging (`future_version`), throttling (`*_throttled`,
+    /// `hot_shard`), and resource pressure (`*_memory_limit_exceeded`).
+    ///
+    /// RETRYABLE: re-running has a real chance of success. These sub-causes are
+    /// deliberately NOT split into separate variants — no consumer distinguishes
+    /// them (`run_txn` only asks "retry?"; the raw FDB code is preserved in the
+    /// payload string for logs). Named `TransientUnavailable`, not `Unavailable`,
+    /// to avoid implying "cluster not reachable" when the cluster is healthy but
+    /// throttling or the transaction simply ran too long.
+    #[error("backend transiently unavailable: {0}")]
+    TransientUnavailable(String),
 
     /// The transaction was explicitly aborted by the caller (e.g. the
-    /// transaction closure returned an application error). Terminal.
+    /// transaction closure returned an application error).
+    ///
+    /// NOT RETRYABLE: this is the caller's own decision, not a backend failure;
+    /// re-running would just abort again.
     #[error("transaction aborted: {0}")]
     Aborted(String),
 
-    /// A terminal backend error that must NOT be retried.
+    /// A terminal backend error (e.g. corrupted value, encoding violation,
+    /// permanent I/O error, `internal_error`, `transaction_too_large`).
     ///
-    /// Not a catch-all for "any backend error": the retryable conditions
-    /// (conflict, unknown commit, timeout, transient unavailability) have their
-    /// own variants above. `Backend` is only the remaining failures re-running
-    /// can't fix (corrupted value, encoding violation, permanent I/O error).
+    /// NOT RETRYABLE: re-running cannot fix it. This is NOT a catch-all — every
+    /// retryable / maybe-committed / deadline condition has its own variant
+    /// above; `Backend` is only the failures that are genuinely permanent.
     #[error("kv backend error: {0}")]
     Backend(String),
 }
 
 impl KvError {
     /// Classifies whether `run_txn` may transparently re-run the closure.
-    /// Excludes `MaybeCommitted`: the mutation may already have applied, so
-    /// retrying a non-idempotent body would double-apply or flip a successful
-    /// CAS to `false`. Only commits that provably did not apply (`Conflict`) or
-    /// never decided (`Timeout`, `Unavailable`) are retryable.
+    ///
+    /// Retryable ⇔ the failure provably did not apply AND another attempt could
+    /// succeed: `Conflict` (commit did not apply) and `TransientUnavailable`
+    /// (transient blip that did not exhaust the deadline). Everything else is
+    /// surfaced to the caller:
+    /// - `MaybeCommitted`: the mutation may already have applied.
+    /// - `DeadlineExceeded`: the caller's wait budget is exhausted.
+    /// - `Aborted` / `Backend`: caller decision / permanent failure.
     pub fn is_retryable(&self) -> bool {
-        matches!(
-            self,
-            KvError::Conflict | KvError::Timeout | KvError::Unavailable(_)
-        )
+        matches!(self, KvError::Conflict | KvError::TransientUnavailable(_))
     }
 
     /// Short, cardinality-bounded label used for metrics. Never contains keys,
@@ -72,8 +110,8 @@ impl KvError {
         match self {
             KvError::Conflict => "conflict",
             KvError::MaybeCommitted => "maybe_committed",
-            KvError::Timeout => "timeout",
-            KvError::Unavailable(_) => "unavailable",
+            KvError::DeadlineExceeded => "deadline_exceeded",
+            KvError::TransientUnavailable(_) => "transient_unavailable",
             KvError::Aborted(_) => "aborted",
             KvError::Backend(_) => "backend",
         }
@@ -89,12 +127,13 @@ mod tests {
 
     #[test]
     fn retryable_classification() {
-        // Auto-retryable: the commit provably did not apply or never decided.
+        // Auto-retryable: provably did not apply and worth another attempt.
         assert!(KvError::Conflict.is_retryable());
-        assert!(KvError::Timeout.is_retryable());
-        assert!(KvError::Unavailable("down".into()).is_retryable());
+        assert!(KvError::TransientUnavailable("down".into()).is_retryable());
 
-        // Not retryable: the write may already have applied, or is terminal.
+        // Not retryable: the write may already have applied, the deadline
+        // budget is exhausted, or the failure is terminal.
+        assert!(!KvError::DeadlineExceeded.is_retryable());
         assert!(!KvError::MaybeCommitted.is_retryable());
         assert!(!KvError::Aborted("app".into()).is_retryable());
         assert!(!KvError::Backend("boom".into()).is_retryable());
@@ -105,8 +144,8 @@ mod tests {
         // Two errors of the same variant produce the same label regardless of
         // their payload, keeping metric cardinality bounded.
         assert_eq!(
-            KvError::Unavailable("a".into()).kind(),
-            KvError::Unavailable("b".into()).kind()
+            KvError::TransientUnavailable("a".into()).kind(),
+            KvError::TransientUnavailable("b".into()).kind()
         );
         assert_eq!(KvError::Backend("x".into()).kind(), "backend");
     }

--- a/curvine-mds/src/kv/fdb.rs
+++ b/curvine-mds/src/kv/fdb.rs
@@ -293,7 +293,9 @@ impl KvTransaction for FdbTxn {
     async fn commit(&mut self) -> KvResult<()> {
         let start = Instant::now();
         self.finished = true;
-        metrics::metrics().txn_in_flight.dec();
+        // Take the transaction BEFORE touching the in-flight gauge: a repeat
+        // commit (trx already None) is a no-op error and must not decrement the
+        // gauge, or it would drive txn_in_flight negative.
         let trx = match self.trx.take() {
             Some(trx) => trx,
             None => {
@@ -307,6 +309,7 @@ impl KvTransaction for FdbTxn {
                 return Err(error);
             }
         };
+        metrics::metrics().txn_in_flight.dec();
         let result = match trx.commit().await {
             Ok(_) => Ok(()),
             // `commit` consumes the txn; on error the `TransactionCommitError`

--- a/curvine-mds/src/kv/fdb.rs
+++ b/curvine-mds/src/kv/fdb.rs
@@ -18,8 +18,8 @@
 //!
 //! Every transaction is created with a `Timeout` (see
 //! [`FdbBackend::txn_timeout_ms`]) so an unreachable cluster surfaces a
-//! `Timeout`/`Unavailable` [`KvError`] within a bounded window instead of
-//! blocking forever.
+//! `DeadlineExceeded`/`TransientUnavailable` [`KvError`] within a bounded window
+//! instead of blocking forever.
 //!
 //! ## Concurrency contract
 //!
@@ -58,56 +58,132 @@ fn ensure_network_started() {
     });
 }
 
-/// Maps a native [`FdbError`] to the abstraction's [`KvError`].
+/// FoundationDB error codes the mapper branches on explicitly, from
+/// flow/error_definitions.h:
+/// https://github.com/apple/foundationdb/blob/main/flow/include/flow/error_definitions.h
 ///
-/// The classification, not the message, is what callers depend on:
-/// - `commit_unknown_result` → [`KvError::MaybeCommitted`] (NOT retryable — the
-///   write may already have applied).
-/// - `not_committed` (1020) → [`KvError::Conflict`], the ONLY code mapped to
-///   Conflict so the conflict metric counts real read/write-set clashes.
-/// - `transaction_timed_out` (1031) → [`KvError::Timeout`].
-/// - any other retryable code (connection loss, coordinator change, stale read
-///   version, …) → [`KvError::Unavailable`]: same retry semantics as Conflict
-///   but kept distinct so availability problems don't pollute conflict metrics.
-/// - everything else → terminal [`KvError::Backend`].
-fn map_fdb_error(err: FdbError) -> KvError {
-    // FDB error codes from flow/error_definitions.h:
-    // https://github.com/apple/foundationdb/blob/main/flow/include/flow/error_definitions.h
-    //   1020 not_committed          — optimistic-concurrency conflict
-    //   1031 transaction_timed_out  — deadline exceeded
-    const NOT_COMMITTED: i32 = 1020;
-    const TRANSACTION_TIMED_OUT: i32 = 1031;
+/// Only codes whose classification the mapper depends on live here; every other
+/// code is handled through FDB's `is_retryable` / `is_maybe_committed` /
+/// `is_retryable_not_committed` predicates rather than by matching a number.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(i32)]
+enum FdbErrorCode {
+    /// 1020 `not_committed`: transaction rejected due to a read/write-set
+    /// conflict. Provably NOT committed — the only code mapped to
+    /// [`KvError::Conflict`] so `mds_kv_txn_conflicts_total` counts real clashes.
+    NotCommitted = 1020,
+    /// 1031 `transaction_timed_out`: per-transaction deadline exceeded. FDB
+    /// treats it as terminal (neither predicate-retryable nor maybe-committed).
+    /// Neither path retries it (the deadline is the caller's wait budget), but
+    /// the mapper keeps the write status distinct: [`KvError::DeadlineExceeded`]
+    /// on a read (provably wrote nothing) vs [`KvError::MaybeCommitted`] on a
+    /// commit (may already have applied).
+    TransactionTimedOut = 1031,
+}
 
-    // Timeout first, for semantic precision. 1031 is itself retryable, so this
-    // branch is not needed for correctness (it would otherwise fall through to
-    // the retryable arm), but surfacing Timeout distinguishes "deadline hit"
-    // from conflict/unavailability in errors and metrics.
-    if err.code() == TRANSACTION_TIMED_OUT {
-        return KvError::Timeout;
+impl FdbErrorCode {
+    /// The raw FDB error code, for comparison against [`FdbError::code`].
+    const fn code(self) -> i32 {
+        self as i32
     }
-    // maybe-committed MUST be classified before the retryable checks below: it
-    // is a SUBSET of retryable, but must NOT be auto-retried (the write may
-    // already have applied — retrying would double-apply).
-    if err.is_maybe_committed() {
-        return KvError::MaybeCommitted;
+}
+
+/// Maps a native [`FdbError`] from a READ/begin operation (`begin`, `get`,
+/// `snapshot_get`, `multi_get`) to the abstraction's [`KvError`].
+///
+/// `transaction_timed_out` (1031) maps to [`KvError::DeadlineExceeded`] — a read
+/// that hit the per-transaction deadline provably wrote nothing, so it is
+/// surfaced (NOT auto-retried: the deadline is the caller's wait budget). This
+/// is the mirror of the commit path, where the same 1031 becomes
+/// [`KvError::MaybeCommitted`] because a commit that timed out may already have
+/// applied. Keeping the two distinct preserves that write-status information
+/// and keeps errors/metrics precise, even though neither is retried.
+fn map_fdb_read_error(err: FdbError) -> KvError {
+    if err.code() == FdbErrorCode::TransactionTimedOut.code() {
+        return KvError::DeadlineExceeded;
     }
-    // Only the genuine optimistic-concurrency conflict (not_committed) maps to
-    // Conflict, so `mds_kv_txn_conflicts_total` counts real read/write-set
-    // clashes and nothing else. Network/cluster availability errors are ALSO
-    // retryable, but lumping them into Conflict would pollute that metric and
-    // mislead operators into diagnosing contention when the cluster is simply
-    // unreachable.
-    if err.code() == NOT_COMMITTED {
+    if err.code() == FdbErrorCode::NotCommitted.code() {
+        // Genuine optimistic-concurrency conflict: the ONLY code mapped to
+        // Conflict so `mds_kv_txn_conflicts_total` counts real clashes.
         return KvError::Conflict;
     }
-    // Every other retryable error — connection_failed (1026), coordinators
-    // changed (1027), transaction_too_old (1007), future_version (1009),
-    // cluster_version_changed (1039), etc. — is a backend availability /
-    // transient condition, not a concurrency conflict. Same retry semantics as
-    // Conflict, but classified as Unavailable so metrics stay meaningful.
+    // Every other retryable code — connection_failed, coordinators_changed,
+    // transaction_too_old, future_version, throttling, etc. — is a transient
+    // condition worth retrying, but NOT a concurrency conflict. Collapsed into
+    // one variant (no consumer distinguishes the sub-causes; the raw code stays
+    // in the payload for logs) and named TransientUnavailable so it does not
+    // imply "cluster unreachable" when the cluster is merely throttling or the
+    // txn ran too long.
     if err.is_retryable() {
-        return KvError::Unavailable(format!("fdb error_code {}: {}", err.code(), err.message()));
+        return KvError::TransientUnavailable(format!(
+            "fdb error_code {}: {}",
+            err.code(),
+            err.message()
+        ));
     }
+    KvError::Backend(format!("fdb error_code {}: {}", err.code(), err.message()))
+}
+
+/// Maps a native [`FdbError`] from a COMMIT to the abstraction's [`KvError`].
+///
+/// A commit that fails may already have applied. The invariant `run_txn` relies
+/// on: NEVER auto-retry a commit unless FDB can PROVE it did not apply. FDB's
+/// `is_retryable_not_committed()` predicate (fdb_c.cpp `RETRYABLE_NOT_COMMITTED`
+/// set: not_committed 1020, transaction_too_old, future_version, database_locked,
+/// throttled codes, …) is exactly "retryable AND provably not committed". So:
+///
+/// - provably-not-committed → [`KvError::Conflict`] (1020) / [`KvError::TransientUnavailable`]
+///   (the rest) — safe to re-run;
+/// - everything else that is not a terminal error — `commit_unknown_result`
+///   (1021), `commit_unknown_result_fatal` (1022), `request_maybe_delivered`
+///   (1030), `transaction_timed_out` (1031), `cluster_version_changed`, … — is
+///   treated as [`KvError::MaybeCommitted`] (NOT retryable; the write may
+///   already have applied, so re-running a non-idempotent body would
+///   double-apply or flip a successful CAS to `false`).
+///
+/// This is why the mapper is split by operation: on a read, 1031 is a
+/// [`KvError::DeadlineExceeded`]; on a commit, 1031 is [`KvError::MaybeCommitted`].
+fn map_fdb_commit_error(err: FdbError) -> KvError {
+    // Provably-not-committed (incl. the 1020 conflict) is the ONLY class safe to
+    // re-run after a commit.
+    if err.is_retryable_not_committed() {
+        if err.code() == FdbErrorCode::NotCommitted.code() {
+            // Genuine optimistic-concurrency conflict — the only code mapped to
+            // Conflict so `mds_kv_txn_conflicts_total` counts real clashes.
+            return KvError::Conflict;
+        }
+        // The rest of the retryable-not-committed set (transaction_too_old,
+        // future_version, throttled codes, …): provably not committed and worth
+        // retrying, but not a conflict — so TransientUnavailable, not Conflict.
+        return KvError::TransientUnavailable(format!(
+            "fdb error_code {}: {}",
+            err.code(),
+            err.message()
+        ));
+    }
+    // Could have committed — the write may already have applied, so this MUST
+    // NOT be auto-retried (re-running a non-idempotent body would double-apply
+    // or flip a successful CAS to `false`). Two sources, because FDB's own
+    // maybe-committed predicate is INCOMPLETE for the commit path:
+    //   - `is_maybe_committed()`: commit_unknown_result (1021),
+    //     cluster_version_changed — FDB itself labels these maybe-committed.
+    //     (Internally FDB folds request_maybe_delivered / never_reply into 1021;
+    //     see NativeAPI.actor.cpp tryCommit catch block.)
+    //   - transaction_timed_out (1031): NOT covered by is_maybe_committed().
+    //     1031 is the *outer* per-txn deadline (a Timeout option timer), not a
+    //     commit-RPC status, so it can fire at ANY point — including while a
+    //     commit request is in flight. Once the commit RPC is sent, the client
+    //     cannot know whether it applied (FDB's own tryCommit comment: the
+    //     commit "might even still be in flight"). So a 1031 on the commit path
+    //     means the commit status is genuinely unknown → MaybeCommitted. This is
+    //     exactly why the mapper is split by operation: on a read 1031 provably
+    //     wrote nothing (DeadlineExceeded); on a commit it may have applied.
+    if err.is_maybe_committed() || err.code() == FdbErrorCode::TransactionTimedOut.code() {
+        return KvError::MaybeCommitted;
+    }
+    // Everything else is a terminal, permanent error (e.g. internal_error,
+    // transaction_too_large): the commit provably did not apply and retrying
+    // would not help.
     KvError::Backend(format!("fdb error_code {}: {}", err.code(), err.message()))
 }
 
@@ -129,7 +205,17 @@ impl FdbBackend {
         if cluster_file.is_empty() {
             return Err(KvError::Backend("fdb cluster file path is empty".into()));
         }
-        let db = Database::from_path(cluster_file).map_err(map_fdb_error)?;
+        // Enforce the fail-fast contract at the layer that applies the option:
+        // FDB TransactionOption::Timeout(0) means "no timeout" (wait forever),
+        // which would let begin/commit hang on an unreachable cluster. MdsConf
+        // rejects <= 0, but open() is public, so guard here too — a direct
+        // caller must not be able to construct a backend that never times out.
+        if txn_timeout_ms <= 0 {
+            return Err(KvError::Backend(format!(
+                "fdb txn_timeout_ms must be greater than zero, got {txn_timeout_ms}"
+            )));
+        }
+        let db = Database::from_path(cluster_file).map_err(map_fdb_read_error)?;
         Ok(Self {
             db: Arc::new(db),
             txn_timeout_ms,
@@ -146,10 +232,10 @@ impl KvBackend for FdbBackend {
     async fn begin(&self) -> KvResult<Box<dyn KvTransaction>> {
         let start = Instant::now();
         let result: KvResult<Transaction> = (|| {
-            let trx = self.db.create_trx().map_err(map_fdb_error)?;
+            let trx = self.db.create_trx().map_err(map_fdb_read_error)?;
             // Bound how long any operation on this txn waits on a stuck cluster.
             trx.set_option(TransactionOption::Timeout(self.txn_timeout_ms))
-                .map_err(map_fdb_error)?;
+                .map_err(map_fdb_read_error)?;
             Ok(trx)
         })();
         let trx = match result {
@@ -171,7 +257,7 @@ impl KvBackend for FdbBackend {
         // "reads observe a snapshot taken when the transaction began" contract
         // (and the memory backend's begin-snapshot behavior).
         if let Err(err) = trx.get_read_version().await {
-            let error = map_fdb_error(err);
+            let error = map_fdb_read_error(err);
             metrics::metrics().observe(
                 BACKEND_NAME,
                 metrics::op::BEGIN,
@@ -223,7 +309,7 @@ impl KvTransaction for FdbTxn {
             .trx()?
             .get(key, false)
             .await
-            .map_err(map_fdb_error)
+            .map_err(map_fdb_read_error)
             .map(|opt| opt.map(|slice| slice.to_vec()));
         observe_read(metrics::op::GET, start, &result);
         result
@@ -237,7 +323,7 @@ impl KvTransaction for FdbTxn {
             .trx()?
             .get(key, true)
             .await
-            .map_err(map_fdb_error)
+            .map_err(map_fdb_read_error)
             .map(|opt| opt.map(|slice| slice.to_vec()));
         observe_read(metrics::op::SNAPSHOT_GET, start, &result);
         result
@@ -255,7 +341,7 @@ impl KvTransaction for FdbTxn {
             match fut.await {
                 Ok(slice) => out.push(slice.map(|s| s.to_vec())),
                 Err(err) => {
-                    error = Some(map_fdb_error(err));
+                    error = Some(map_fdb_read_error(err));
                     break;
                 }
             }
@@ -314,7 +400,7 @@ impl KvTransaction for FdbTxn {
             Ok(_) => Ok(()),
             // `commit` consumes the txn; on error the `TransactionCommitError`
             // derefs to the underlying `FdbError`, which carries the code.
-            Err(commit_err) => Err(map_fdb_error(commit_err.into())),
+            Err(commit_err) => Err(map_fdb_commit_error(commit_err.into())),
         };
         metrics::metrics().observe(
             BACKEND_NAME,
@@ -354,4 +440,90 @@ fn observe_read<T>(op: &'static str, start: Instant, result: &KvResult<T>) {
         start,
         &result.as_ref().map(|_| ()).map_err(|e| e.clone()),
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Codes the mapper does NOT branch on individually (handled via FDB
+    // predicates); kept local to the test to exercise those predicate paths.
+    // The branched-on codes come from `FdbErrorCode` so the test and the mapper
+    // cannot drift.
+    const COMMIT_UNKNOWN_RESULT: i32 = 1021; // may or may not have committed
+    const INTERNAL_ERROR: i32 = 4100; // terminal, non-retryable
+
+    /// The whole point of splitting the mapper by operation: the SAME FDB code
+    /// classifies differently on a read (replay-safe) vs a commit (may already
+    /// have applied). If someone swaps an arm, one of these rows fails.
+    ///
+    /// | code | read path            | commit path      |
+    /// |------|----------------------|------------------|
+    /// | 1020 | Conflict             | Conflict         | provably not committed
+    /// | 1021 | TransientUnavailable | MaybeCommitted   | commit_unknown_result
+    /// | 1031 | DeadlineExceeded     | MaybeCommitted   | timed out; state unknown
+    /// | 4100 | Backend              | Backend          | terminal
+    #[test]
+    fn error_mapping_is_split_by_operation() {
+        // (code, read classification, commit classification)
+        // We compare on `kind()` labels to avoid matching the message payload
+        // that TransientUnavailable/Backend carry.
+        let cases: &[(i32, &str, &str)] = &[
+            (FdbErrorCode::NotCommitted.code(), "conflict", "conflict"),
+            (
+                COMMIT_UNKNOWN_RESULT,
+                "transient_unavailable",
+                "maybe_committed",
+            ),
+            (
+                FdbErrorCode::TransactionTimedOut.code(),
+                "deadline_exceeded",
+                "maybe_committed",
+            ),
+            (INTERNAL_ERROR, "backend", "backend"),
+        ];
+
+        for &(code, want_read, want_commit) in cases {
+            let read = map_fdb_read_error(FdbError::from_code(code));
+            assert_eq!(
+                read.kind(),
+                want_read,
+                "read path: code {code} expected {want_read}, got {read:?}"
+            );
+
+            let commit = map_fdb_commit_error(FdbError::from_code(code));
+            assert_eq!(
+                commit.kind(),
+                want_commit,
+                "commit path: code {code} expected {want_commit}, got {commit:?}"
+            );
+        }
+    }
+
+    /// A transaction that hit the per-txn deadline (1031) must NOT be
+    /// retryable on either path: on a commit `run_txn` could re-run a
+    /// possibly-applied write (double-apply); on a read it would defeat
+    /// fail-fast by multiplying the caller's wait budget. The two still map to
+    /// distinct errors so write status is preserved: MaybeCommitted (commit)
+    /// vs DeadlineExceeded (read).
+    #[test]
+    fn deadline_exceeded_is_not_retryable_on_either_path() {
+        let commit = map_fdb_commit_error(FdbError::from_code(
+            FdbErrorCode::TransactionTimedOut.code(),
+        ));
+        assert!(
+            !commit.is_retryable(),
+            "commit-path 1031 must not be retryable (may already have applied), got {commit:?}"
+        );
+        assert!(matches!(commit, KvError::MaybeCommitted));
+
+        let read = map_fdb_read_error(FdbError::from_code(
+            FdbErrorCode::TransactionTimedOut.code(),
+        ));
+        assert!(
+            !read.is_retryable(),
+            "read-path 1031 must not be retryable (deadline budget exhausted), got {read:?}"
+        );
+        assert!(matches!(read, KvError::DeadlineExceeded));
+    }
 }

--- a/curvine-mds/src/kv/fdb.rs
+++ b/curvine-mds/src/kv/fdb.rs
@@ -1,0 +1,354 @@
+//! FoundationDB [`KvBackend`] implementation.
+//!
+//! This backend maps the generic KV abstraction onto the FoundationDB C
+//! client (via the `foundationdb` crate).
+//!
+//! ## Network lifecycle
+//!
+//! The FDB C client requires a process-global network event loop that may be
+//! started exactly once. [`FdbBackend::open`] boots it on first use through a
+//! [`once_cell::sync::OnceCell`] and INTENTIONALLY LEAKS the
+//! [`NetworkAutoStop`] handle: dropping it would call `fdb_stop_network`,
+//! which blocks on the network thread. Leaking it means a hung or unreachable
+//! FDB cluster can never wedge process shutdown on the network stop — the OS
+//! reclaims the thread on exit. This satisfies the PR requirement that "FDB
+//! unavailable or shut down must not block process exit".
+//!
+//! ## Fail-fast, not hang
+//!
+//! Every transaction is created with a `Timeout` (see
+//! [`FdbBackend::txn_timeout_ms`]) so an unreachable cluster surfaces a
+//! `Timeout`/`Unavailable` [`KvError`] within a bounded window instead of
+//! blocking forever.
+//!
+//! ## Concurrency contract
+//!
+//! FDB natively provides serializable snapshot isolation, which is exactly the
+//! contract [`KvTransaction`] documents: `get`/`multi_get` add keys to the
+//! read-conflict set, `snapshot_get` reads the same snapshot without
+//! conflict tracking, blind writes don't conflict, and a concurrent delete of
+//! a read key conflicts like an overwrite. The same backend-agnostic contract
+//! tests that pin the memory backend run against this one unchanged.
+
+use crate::kv::backend::{KvBackend, KvTransaction};
+use crate::kv::error::{KvError, KvResult};
+use crate::kv::metrics;
+use async_trait::async_trait;
+use foundationdb::options::{ConflictRangeType, TransactionOption};
+use foundationdb::{api::NetworkAutoStop, Database, FdbError, Transaction};
+use once_cell::sync::OnceCell;
+use std::sync::Arc;
+use std::time::Instant;
+
+const BACKEND_NAME: &str = "fdb";
+
+/// Process-global FDB network guard. Leaked on purpose (see module docs); the
+/// `OnceCell` only guarantees the network is booted exactly once.
+static FDB_NETWORK: OnceCell<()> = OnceCell::new();
+
+/// Boots the FDB client network loop once per process. The returned handle is
+/// leaked so a stuck cluster can never block `fdb_stop_network` at shutdown.
+fn ensure_network_started() {
+    FDB_NETWORK.get_or_init(|| {
+        // SAFETY: called exactly once (guarded by OnceCell). We deliberately
+        // leak the guard instead of storing it: dropping it would stop the
+        // network and could block on a hung cluster during exit.
+        let network: NetworkAutoStop = unsafe { foundationdb::boot() };
+        std::mem::forget(network);
+    });
+}
+
+/// Maps a native [`FdbError`] to the abstraction's [`KvError`].
+///
+/// The classification, not the message, is what callers depend on:
+/// - `commit_unknown_result` → [`KvError::MaybeCommitted`] (NOT retryable — the
+///   write may already have applied).
+/// - `not_committed` (1020) → [`KvError::Conflict`], the ONLY code mapped to
+///   Conflict so the conflict metric counts real read/write-set clashes.
+/// - `transaction_timed_out` (1031) → [`KvError::Timeout`].
+/// - any other retryable code (connection loss, coordinator change, stale read
+///   version, …) → [`KvError::Unavailable`]: same retry semantics as Conflict
+///   but kept distinct so availability problems don't pollute conflict metrics.
+/// - everything else → terminal [`KvError::Backend`].
+fn map_fdb_error(err: FdbError) -> KvError {
+    // FDB error codes from flow/error_definitions.h:
+    // https://github.com/apple/foundationdb/blob/main/flow/include/flow/error_definitions.h
+    //   1020 not_committed          — optimistic-concurrency conflict
+    //   1031 transaction_timed_out  — deadline exceeded
+    const NOT_COMMITTED: i32 = 1020;
+    const TRANSACTION_TIMED_OUT: i32 = 1031;
+
+    // Timeout first, for semantic precision. 1031 is itself retryable, so this
+    // branch is not needed for correctness (it would otherwise fall through to
+    // the retryable arm), but surfacing Timeout distinguishes "deadline hit"
+    // from conflict/unavailability in errors and metrics.
+    if err.code() == TRANSACTION_TIMED_OUT {
+        return KvError::Timeout;
+    }
+    // maybe-committed MUST be classified before the retryable checks below: it
+    // is a SUBSET of retryable, but must NOT be auto-retried (the write may
+    // already have applied — retrying would double-apply).
+    if err.is_maybe_committed() {
+        return KvError::MaybeCommitted;
+    }
+    // Only the genuine optimistic-concurrency conflict (not_committed) maps to
+    // Conflict, so `mds_kv_txn_conflicts_total` counts real read/write-set
+    // clashes and nothing else. Network/cluster availability errors are ALSO
+    // retryable, but lumping them into Conflict would pollute that metric and
+    // mislead operators into diagnosing contention when the cluster is simply
+    // unreachable.
+    if err.code() == NOT_COMMITTED {
+        return KvError::Conflict;
+    }
+    // Every other retryable error — connection_failed (1026), coordinators
+    // changed (1027), transaction_too_old (1007), future_version (1009),
+    // cluster_version_changed (1039), etc. — is a backend availability /
+    // transient condition, not a concurrency conflict. Same retry semantics as
+    // Conflict, but classified as Unavailable so metrics stay meaningful.
+    if err.is_retryable() {
+        return KvError::Unavailable(format!("fdb error_code {}: {}", err.code(), err.message()));
+    }
+    KvError::Backend(format!("fdb error_code {}: {}", err.code(), err.message()))
+}
+
+/// FoundationDB-backed KV store. Cheap to `clone`; all clones share one
+/// [`Database`] handle.
+#[derive(Clone)]
+pub struct FdbBackend {
+    db: Arc<Database>,
+    txn_timeout_ms: i32,
+}
+
+impl FdbBackend {
+    /// Opens the backend from a FoundationDB cluster file path (the same file
+    /// `fdbcli -C <path>` accepts). Boots the process-global network on first
+    /// use.
+    pub fn open(cluster_file: &str, txn_timeout_ms: i32) -> KvResult<Self> {
+        ensure_network_started();
+        let cluster_file = cluster_file.trim();
+        if cluster_file.is_empty() {
+            return Err(KvError::Backend("fdb cluster file path is empty".into()));
+        }
+        let db = Database::from_path(cluster_file).map_err(map_fdb_error)?;
+        Ok(Self {
+            db: Arc::new(db),
+            txn_timeout_ms,
+        })
+    }
+}
+
+#[async_trait]
+impl KvBackend for FdbBackend {
+    fn name(&self) -> &'static str {
+        BACKEND_NAME
+    }
+
+    async fn begin(&self) -> KvResult<Box<dyn KvTransaction>> {
+        let start = Instant::now();
+        let result: KvResult<Transaction> = (|| {
+            let trx = self.db.create_trx().map_err(map_fdb_error)?;
+            // Bound how long any operation on this txn waits on a stuck cluster.
+            trx.set_option(TransactionOption::Timeout(self.txn_timeout_ms))
+                .map_err(map_fdb_error)?;
+            Ok(trx)
+        })();
+        let trx = match result {
+            Ok(trx) => trx,
+            Err(error) => {
+                metrics::metrics().observe(
+                    BACKEND_NAME,
+                    metrics::op::BEGIN,
+                    start,
+                    &Err(error.clone()),
+                );
+                return Err(error);
+            }
+        };
+        // Eagerly resolve the read version so the snapshot is pinned at begin,
+        // not lazily at the first read. Without this, FDB picks the read
+        // version on the first get, and a write committed between begin and
+        // that get would leak into the snapshot — violating the trait's
+        // "reads observe a snapshot taken when the transaction began" contract
+        // (and the memory backend's begin-snapshot behavior).
+        if let Err(err) = trx.get_read_version().await {
+            let error = map_fdb_error(err);
+            metrics::metrics().observe(
+                BACKEND_NAME,
+                metrics::op::BEGIN,
+                start,
+                &Err(error.clone()),
+            );
+            return Err(error);
+        }
+        metrics::metrics().observe(BACKEND_NAME, metrics::op::BEGIN, start, &Ok(()));
+        metrics::metrics().txn_in_flight.inc();
+        Ok(Box::new(FdbTxn {
+            trx: Some(trx),
+            finished: false,
+        }))
+    }
+}
+
+/// The end-key of the single-key conflict range `[key, key\0)`; adding this
+/// range to the read-conflict set makes an explicit read-conflict cover exactly
+/// `key`.
+fn key_successor(key: &[u8]) -> Vec<u8> {
+    let mut end = Vec::with_capacity(key.len() + 1);
+    end.extend_from_slice(key);
+    end.push(0x00);
+    end
+}
+
+struct FdbTxn {
+    /// `Some` until commit/rollback/drop; taken out to move into `commit`,
+    /// which consumes the `Transaction`.
+    trx: Option<Transaction>,
+    finished: bool,
+}
+
+impl FdbTxn {
+    fn trx(&self) -> KvResult<&Transaction> {
+        self.trx
+            .as_ref()
+            .ok_or_else(|| KvError::Backend("transaction already finished".into()))
+    }
+}
+
+#[async_trait]
+impl KvTransaction for FdbTxn {
+    async fn get(&mut self, key: &[u8]) -> KvResult<Option<Vec<u8>>> {
+        let start = Instant::now();
+        // snapshot = false ⇒ the read is added to the read-conflict set.
+        let result = self
+            .trx()?
+            .get(key, false)
+            .await
+            .map_err(map_fdb_error)
+            .map(|opt| opt.map(|slice| slice.to_vec()));
+        observe_read(metrics::op::GET, start, &result);
+        result
+    }
+
+    async fn snapshot_get(&mut self, key: &[u8]) -> KvResult<Option<Vec<u8>>> {
+        let start = Instant::now();
+        // snapshot = true ⇒ same snapshot as `get`, but NOT added to the
+        // read-conflict set, so a concurrent change won't conflict at commit.
+        let result = self
+            .trx()?
+            .get(key, true)
+            .await
+            .map_err(map_fdb_error)
+            .map(|opt| opt.map(|slice| slice.to_vec()));
+        observe_read(metrics::op::SNAPSHOT_GET, start, &result);
+        result
+    }
+
+    async fn multi_get(&mut self, keys: &[Vec<u8>]) -> KvResult<Vec<Option<Vec<u8>>>> {
+        let start = Instant::now();
+        let trx = self.trx()?;
+        let mut out = Vec::with_capacity(keys.len());
+        let mut error: Option<KvError> = None;
+        // FDB futures pipeline: issue all reads, then await. Each `get` tracks
+        // the key in the read-conflict set, matching the trait contract.
+        let futures: Vec<_> = keys.iter().map(|k| trx.get(k, false)).collect();
+        for fut in futures {
+            match fut.await {
+                Ok(slice) => out.push(slice.map(|s| s.to_vec())),
+                Err(err) => {
+                    error = Some(map_fdb_error(err));
+                    break;
+                }
+            }
+        }
+        let result = match error {
+            Some(err) => Err(err),
+            None => Ok(out),
+        };
+        observe_read(metrics::op::MULTI_GET, start, &result);
+        result
+    }
+
+    fn put(&mut self, key: &[u8], value: &[u8]) {
+        if let Some(trx) = self.trx.as_ref() {
+            metrics::metrics().observe_kv_size(BACKEND_NAME, key.len(), value.len());
+            trx.set(key, value);
+        }
+    }
+
+    fn delete(&mut self, key: &[u8]) {
+        if let Some(trx) = self.trx.as_ref() {
+            trx.clear(key);
+        }
+    }
+
+    fn add_read_conflict(&mut self, key: &[u8]) {
+        if let Some(trx) = self.trx.as_ref() {
+            let end = key_successor(key);
+            // Best-effort: a failure here would also fail commit; ignore so the
+            // signature matches the trait (no Result).
+            let _ = trx.add_conflict_range(key, &end, ConflictRangeType::Read);
+        }
+    }
+
+    async fn commit(&mut self) -> KvResult<()> {
+        let start = Instant::now();
+        self.finished = true;
+        metrics::metrics().txn_in_flight.dec();
+        let trx = match self.trx.take() {
+            Some(trx) => trx,
+            None => {
+                let error = KvError::Backend("commit on finished transaction".into());
+                metrics::metrics().observe(
+                    BACKEND_NAME,
+                    metrics::op::COMMIT,
+                    start,
+                    &Err(error.clone()),
+                );
+                return Err(error);
+            }
+        };
+        let result = match trx.commit().await {
+            Ok(_) => Ok(()),
+            // `commit` consumes the txn; on error the `TransactionCommitError`
+            // derefs to the underlying `FdbError`, which carries the code.
+            Err(commit_err) => Err(map_fdb_error(commit_err.into())),
+        };
+        metrics::metrics().observe(
+            BACKEND_NAME,
+            metrics::op::COMMIT,
+            start,
+            &result.as_ref().map(|_| ()).map_err(|e| e.clone()),
+        );
+        result
+    }
+
+    fn rollback(&mut self) {
+        if !self.finished {
+            self.finished = true;
+            metrics::metrics().txn_in_flight.dec();
+        }
+        // Dropping the Transaction cancels/destroys it.
+        self.trx = None;
+    }
+}
+
+impl Drop for FdbTxn {
+    fn drop(&mut self) {
+        // A transaction dropped without commit/rollback still releases its
+        // in-flight slot so the gauge stays accurate.
+        if !self.finished {
+            metrics::metrics().txn_in_flight.dec();
+        }
+    }
+}
+
+/// Records the outcome/latency of a read op; reads don't touch the KV-size
+/// histogram (that tracks writes).
+fn observe_read<T>(op: &'static str, start: Instant, result: &KvResult<T>) {
+    metrics::metrics().observe(
+        BACKEND_NAME,
+        op,
+        start,
+        &result.as_ref().map(|_| ()).map_err(|e| e.clone()),
+    );
+}

--- a/curvine-mds/src/kv/metrics.rs
+++ b/curvine-mds/src/kv/metrics.rs
@@ -34,6 +34,12 @@ const LATENCY_BUCKETS_US: &[f64] = &[
     250_000.0,
 ];
 
+/// KV size buckets in bytes. Centred on the ~128B target single-KV budget so the
+/// P50/P95/P99 around it are visible, with headroom for oversized records.
+const KV_SIZE_BUCKETS_BYTES: &[f64] = &[
+    16.0, 32.0, 64.0, 128.0, 256.0, 512.0, 1_024.0, 2_048.0, 4_096.0, 16_384.0, 65_536.0,
+];
+
 /// Process-wide KV metric handles. Registered once on first access.
 pub struct KvMetrics {
     /// Total operations attempted, by backend + op.
@@ -50,6 +56,10 @@ pub struct KvMetrics {
     pub txn_retries_total: CounterVec,
     /// Currently in-flight transactions.
     pub txn_in_flight: Gauge,
+    /// Distribution of key sizes written to the backend, in bytes, by backend.
+    pub kv_key_size_bytes: HistogramVec,
+    /// Distribution of value sizes written to the backend, in bytes, by backend.
+    pub kv_value_size_bytes: HistogramVec,
 }
 
 impl KvMetrics {
@@ -90,6 +100,18 @@ impl KvMetrics {
                 "mds_kv_txn_in_flight",
                 "Currently in-flight KV transactions",
             )?,
+            kv_key_size_bytes: Metrics::new_histogram_vec_with_buckets(
+                "mds_kv_key_size_bytes",
+                "Distribution of KV key sizes in bytes",
+                &["backend"],
+                KV_SIZE_BUCKETS_BYTES,
+            )?,
+            kv_value_size_bytes: Metrics::new_histogram_vec_with_buckets(
+                "mds_kv_value_size_bytes",
+                "Distribution of KV value sizes in bytes",
+                &["backend"],
+                KV_SIZE_BUCKETS_BYTES,
+            )?,
         })
     }
 
@@ -115,6 +137,17 @@ impl KvMetrics {
     /// Records a retry of a transaction closure.
     pub fn record_retry(&self, backend: &str) {
         self.txn_retries_total.with_label_values(&[backend]).inc();
+    }
+
+    /// Records the byte size of a key/value pair buffered for write, so the
+    /// KV-size distribution (P50/P95/P99 vs the ~128B budget) is observable.
+    pub fn observe_kv_size(&self, backend: &str, key_len: usize, value_len: usize) {
+        self.kv_key_size_bytes
+            .with_label_values(&[backend])
+            .observe(key_len as f64);
+        self.kv_value_size_bytes
+            .with_label_values(&[backend])
+            .observe(value_len as f64);
     }
 }
 

--- a/curvine-mds/src/kv/mod.rs
+++ b/curvine-mds/src/kv/mod.rs
@@ -9,11 +9,13 @@
 
 mod backend;
 mod error;
+mod fdb;
 mod memory;
 pub mod metrics;
 
 pub use backend::{run_txn, KvBackend, KvTransaction, DEFAULT_MAX_RETRIES};
 pub use error::{KvError, KvResult};
+pub use fdb::FdbBackend;
 pub use memory::{FaultInjector, MemoryBackend};
 
 #[cfg(test)]

--- a/curvine-mds/src/lib.rs
+++ b/curvine-mds/src/lib.rs
@@ -1,6 +1,7 @@
 mod kv;
 mod server;
 
+pub use kv::FdbBackend;
 pub use kv::{
     run_txn, FaultInjector, KvBackend, KvError, KvResult, KvTransaction, MemoryBackend,
     DEFAULT_MAX_RETRIES,

--- a/curvine-mds/src/server.rs
+++ b/curvine-mds/src/server.rs
@@ -1,4 +1,4 @@
-use curvine_config::ClusterConf;
+use curvine_config::{ClusterConf, KvBackendType};
 use curvine_core_error::{err_box, CommonResult};
 use curvine_runtime::common::Logger;
 use curvine_runtime::runtime::{AsyncRuntime, RpcRuntime, Runtime};
@@ -6,8 +6,11 @@ use log::info;
 use std::sync::Arc;
 use tokio::sync::watch;
 
+use crate::{FdbBackend, KvBackend, MemoryBackend};
+
 pub struct Mds {
     conf: ClusterConf,
+    backend: Arc<dyn KvBackend>,
     rt: Arc<Runtime>,
     shutdown_tx: watch::Sender<bool>,
     shutdown_rx: watch::Receiver<bool>,
@@ -21,6 +24,13 @@ impl Mds {
         conf.mds.init()?;
         Logger::init(conf.mds.log.clone());
 
+        let backend: Arc<dyn KvBackend> = match conf.mds.kv_backend {
+            KvBackendType::Memory => Arc::new(MemoryBackend::new()),
+            KvBackendType::Fdb => Arc::new(
+                FdbBackend::open(&conf.mds.fdb_cluster_file, conf.mds.fdb_txn_timeout_ms)
+                    .map_err(|error| curvine_core_error::CommonError::from(error.to_string()))?,
+            ),
+        };
         let rt = Arc::new(AsyncRuntime::new(
             "mds",
             conf.mds.io_threads,
@@ -29,6 +39,7 @@ impl Mds {
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
         Ok(Self {
             conf,
+            backend,
             rt,
             shutdown_tx,
             shutdown_rx,
@@ -39,8 +50,16 @@ impl Mds {
         &self.conf
     }
 
+    pub fn backend(&self) -> &Arc<dyn KvBackend> {
+        &self.backend
+    }
+
     pub async fn start(&mut self) -> CommonResult<()> {
-        info!("curvine-mds started: cluster_id={}", self.conf.cluster_id);
+        info!(
+            "curvine-mds started: cluster_id={}, backend={}",
+            self.conf.cluster_id,
+            self.backend.name()
+        );
         Ok(())
     }
 
@@ -92,6 +111,28 @@ impl Mds {
 mod tests {
     use super::*;
 
+    fn mds_with_backend(mut conf: ClusterConf, backend: Arc<dyn KvBackend>) -> CommonResult<Mds> {
+        if !conf.mds.enabled {
+            return err_box!("mds service is disabled; set mds.enabled=true to start it");
+        }
+        conf.mds.init()?;
+        Logger::init(conf.mds.log.clone());
+
+        let rt = Arc::new(AsyncRuntime::new(
+            "mds",
+            conf.mds.io_threads,
+            conf.mds.worker_threads,
+        ));
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        Ok(Mds {
+            conf,
+            backend,
+            rt,
+            shutdown_tx,
+            shutdown_rx,
+        })
+    }
+
     #[test]
     fn refuses_to_start_when_disabled() {
         let conf = ClusterConf::default();
@@ -102,7 +143,10 @@ mod tests {
     fn starts_and_stops_with_explicit_shutdown() {
         let mut conf = ClusterConf::default();
         conf.mds.enabled = true;
-        let mut mds = Mds::with_conf(conf).unwrap();
+        // Use the memory backend so init() does not require an FDB connection
+        // string (this test exercises the lifecycle, not the backend).
+        conf.mds.kv_backend = KvBackendType::Memory;
+        let mut mds = mds_with_backend(conf, Arc::new(MemoryBackend::new())).unwrap();
         mds.shutdown();
 
         let rt = mds.rt.clone();
@@ -110,5 +154,15 @@ mod tests {
             mds.start().await.unwrap();
             mds.wait_for_shutdown().await.unwrap();
         });
+    }
+
+    #[test]
+    fn selects_memory_backend_from_config() {
+        let mut conf = ClusterConf::default();
+        conf.mds.enabled = true;
+        conf.mds.kv_backend = KvBackendType::Memory;
+
+        let mds = Mds::with_conf(conf).unwrap();
+        assert_eq!(mds.backend().name(), "memory");
     }
 }

--- a/etc/curvine-cluster.toml
+++ b/etc/curvine-cluster.toml
@@ -104,6 +104,18 @@ journal_dir = "testing/journal"
 # This is trusted administrator configuration and is not capped by the master.
 weight = 1
 dir_reserved = "0"
+# Strict physical free-space floor for Curvine write admission. The worker
+# reports only bytes above this floor, so both new blocks and FileLayout rewrite
+# staging copies are rejected if their full reservation would cross it. Existing
+# committed data remains readable, but files on a low-space worker may be
+# temporarily non-writable. This protects shared-device space for other apps.
+#
+# Rewrites do not bypass the floor: FileLayout keeps committed + staging copies
+# concurrently, and an expanding rewrite reserves the full target block size
+# (for example, rewriting a 10GB block with a 20GB target may need about 30GB at
+# peak). 0.0 disables (default). Range [0.0, 1.0); 0.1 protects 10%.
+# Another app can still consume space after the worker samples the device.
+# free_ratio = 0.1
 data_dir = [
     "[DISK]testing/data",
 ]

--- a/etc/curvine-cluster.toml
+++ b/etc/curvine-cluster.toml
@@ -79,6 +79,13 @@ log = { level = "info", log_dir = "stdout", file_name = "master.log" }
 enabled = false
 rpc_port = 8998
 web_port = 9004
+# KV storage backend. Supported values: "fdb" and "memory".
+# Use "fdb" for production deployments; "memory" is only intended for tests
+# and loses all metadata when the MDS process exits.
+kv_backend = "fdb"
+# Path to the FoundationDB cluster file (the same file `fdbcli -C <path>`
+# accepts). Required when kv_backend = "fdb".
+fdb_cluster_file = "/etc/foundationdb/fdb.cluster"
 log = { level = "info", log_dir = "stdout", file_name = "mds.log" }
 
 
@@ -97,18 +104,6 @@ journal_dir = "testing/journal"
 # This is trusted administrator configuration and is not capped by the master.
 weight = 1
 dir_reserved = "0"
-# Strict physical free-space floor for Curvine write admission. The worker
-# reports only bytes above this floor, so both new blocks and FileLayout rewrite
-# staging copies are rejected if their full reservation would cross it. Existing
-# committed data remains readable, but files on a low-space worker may be
-# temporarily non-writable. This protects shared-device space for other apps.
-#
-# Rewrites do not bypass the floor: FileLayout keeps committed + staging copies
-# concurrently, and an expanding rewrite reserves the full target block size
-# (for example, rewriting a 10GB block with a 20GB target may need about 30GB at
-# peak). 0.0 disables (default). Range [0.0, 1.0); 0.1 protects 10%.
-# Another app can still consume space after the worker samples the device.
-# free_ratio = 0.1
 data_dir = [
     "[DISK]testing/data",
 ]


### PR DESCRIPTION
# Summary

Implement the FoundationDB (FDB) KV backend on top of the generic byte-level KV abstraction added in #1639, and wire it into `curvine-mds` via configuration. This is the persistent storage backend the stateless MDS repositories will build on. The same backend-agnostic contract test suite that pins the memory backend runs unchanged against a real FDB cluster.

# Issue Describe / Design

This is PR 3 of the stateless MDS implementation plan (parent: #951). It builds directly on the KV abstraction from #1639 (PR 2) and introduces no MDS domain types.

Key design decisions:

- **Network lifecycle.** The FDB C client requires a process-global network event loop started exactly once; it is booted lazily via a `OnceCell` and the `NetworkAutoStop` guard is intentionally leaked. Dropping it would call `fdb_stop_network`, which blocks on the network thread and could wedge process shutdown if the cluster is unreachable. Leaking it lets the OS reclaim the thread on exit, satisfying "FDB unavailable or shut down must not block process exit".
- **Fail-fast, not hang.** Every transaction is created with a per-transaction `Timeout` so an unreachable cluster surfaces a bounded error instead of blocking forever.
- **Error classification.** Native `FdbError` is mapped to the abstraction's `KvError` without leaking SDK types. `commit_unknown_result` -> `MaybeCommitted` (NOT retryable — the write may already have applied); `not_committed` (1020) is the only code mapped to `Conflict`, so the conflict metric counts real read/write-set clashes; `transaction_timed_out` (1031) -> `Timeout`; other retryable codes (connection loss, coordinator change, stale read version, …) -> `Unavailable`, kept distinct so availability problems do not pollute conflict metrics.
- **Begin-time snapshot.** `begin()` eagerly resolves the read version so reads observe the snapshot taken when the transaction began, matching the trait contract and the memory backend (FDB otherwise picks the read version lazily on the first read).
- **Metrics.** Transaction latency, conflicts, retries, errors, in-flight gauge, and a KV size distribution histogram.
- **Config.** `kv_backend = "memory" | "fdb"` selects the backend; `fdb_cluster_file` points at a standard FDB cluster file; `fdb_txn_timeout_ms` bounds each transaction.

Out of scope (deferred): range/scan operations are not implemented yet — they will be added in PR 4 when the MountTable repository first needs prefix/range scans. A separate follow-up (tracked in design notes) will add fail-fast / circuit-breaking for prolonged cluster unavailability at the `run_txn` layer.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-mds/src/kv/fdb.rs` | New FDB backend: network bootstrap, transaction lifecycle, error mapping, point ops, begin-time read version | None; new backend |
| `curvine-mds/src/kv/mod.rs` | Wire up the `fdb` module and re-export `FdbBackend` | None; new API |
| `curvine-mds/src/kv/metrics.rs` | Add KV key/value size histograms and `observe_kv_size` | Adds MDS metrics |
| `curvine-mds/src/kv/contract_tests.rs` | Run the shared contract suite against a real cluster (gated by `CURVINE_MDS_FDB_CLUSTER`); per-run key prefix isolates the keyspace; add an unreachable-cluster fail-fast test | Test-only |
| `curvine-mds/src/lib.rs` | Export `FdbBackend` | None; new API |
| `curvine-mds/src/server.rs` | Select memory/FDB backend from config | None when `kv_backend = memory` |
| `crates/common/curvine-config/src/mds_conf.rs` | Add `kv_backend`, `fdb_cluster_file`, `fdb_txn_timeout_ms` with validation | New config fields; defaults preserve behavior |
| `crates/common/curvine-config/src/lib.rs` | Export `KvBackendType` | None; new API |
| `curvine-mds/Cargo.toml`, `Cargo.toml`, `Cargo.lock` | Add `foundationdb` dependency | New dependency |
| `etc/curvine-cluster.toml`, `curvine-docker/deploy/example/conf/curvine-cluster.toml` | Document the new MDS KV backend options | Docs/config examples |

# Test verified

- `cargo test -p curvine-mds -p curvine-config` — memory backend contract suite, config validation, and server backend selection all pass.
- Against a real FoundationDB 7.3 cluster (`CURVINE_MDS_FDB_CLUSTER=<cluster file>`): the identical contract suite (`fdb_backend_satisfies_contract`) passes, covering point ops, batch delete, arbitrary/UTF-8 keys, transactional read-modify-write, CAS, concurrent write/delete conflicts, snapshot reads, begin-time snapshot, and unknown-commit behavior.
- `fdb_unreachable_cluster_does_not_hang` — points the backend at an unreachable address and asserts `begin()` fails fast within the per-transaction timeout (bounded, does not block process exit).
- `cargo fmt --check` and `cargo clippy --all-targets -- --deny=warnings` clean for both crates, with and without a reachable cluster.

# Dependencies

Builds on #1639 (PR 2: generic KV abstraction and memory backend). No dependency on other in-flight PRs.
