### PR TITLE
docs(agents): add cv-codegraph skill for code exploration

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -37,6 +37,7 @@ rm -rf .claude/skills && ln -sfn ../.agents/skills .claude/skills
 | Skill | Stage |
 | ----- | ----- |
 | `cv-add-skills` | Meta — add/update cv skills |
+| `cv-codegraph` | Code exploration — install/init CodeGraph, prefer before grep |
 | `cv-tasks-breakdown` | Plan → small tasks + sub-issues |
 | `cv-create-issue` | File GitHub issue |
 | `cv-handle-issue` | Fix issue (plan first, then code) |

--- a/.agents/skills/cv-add-skills/SKILL.md
+++ b/.agents/skills/cv-add-skills/SKILL.md
@@ -146,6 +146,7 @@ ls -la .github/skills .cursor/skills .claude/skills
 | Skill | Stage |
 | ----- | ----- |
 | `cv-add-skills` | Meta — add/update skills |
+| `cv-codegraph` | Code exploration — CodeGraph setup and usage |
 | `cv-create-issue` | Issue |
 | `cv-create-pr` | PR |
 | `cv-csi-test` | Testing |

--- a/.agents/skills/cv-codegraph/SKILL.md
+++ b/.agents/skills/cv-codegraph/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cv-codegraph
-description: Install, initialize, and use CodeGraph for Curvine code exploration. Prefer CodeGraph before grep, find, or manual file reads when locating or understanding code. Use when exploring the codebase, tracing call paths, finding symbols, or when CodeGraph MCP or CLI is available.
+description: Use CodeGraph for Curvine code exploration when the MCP tool or local index is already available; prefer it over repo-wide grep when locating or understanding code. Human one-time setup covers CLI install, MCP wiring, and indexing. Use when exploring the codebase, tracing call paths, or finding symbols.
 ---
 
 # cv-codegraph
@@ -11,26 +11,48 @@ description: Install, initialize, and use CodeGraph for Curvine code exploration
 
 - Exploring or locating code in Curvine
 - Tracing how symbols connect across files or crates
-- Answering "where is X" or "how does X work" before opening files
-- Any task where you would reach for `grep`, `find`, or broad file reads
+- Answering "where is X" or "how does X work" before broad repo scans
+- Any task where you would reach for `grep`, `find`, or reading many files
 
-**Priority rule:** When `.codegraph/` exists or the CodeGraph MCP tool is available, use CodeGraph **first**. Fall back to grep/read only when CodeGraph is unavailable, not indexed, or does not cover the target (configs, docs, non-indexed files).
+**Priority rule:** When `.codegraph/` exists or a `codegraph_explore` MCP tool is available, use CodeGraph **first**. Fall back to grep/read when CodeGraph is unavailable, not indexed, does not cover the target (configs, docs), or may be stale (see Limitations).
 
-## Setup
+## Human One-Time Setup
 
-Install the CLI if `codegraph` is not on `PATH`:
+Developers run this once per machine. **Agents must not run these steps mid-task** — if the index or MCP tool is missing, fall back to grep/read and note that setup is needed.
+
+### 1. Install the CLI
+
+Download the installer, review it if desired, then run it:
 
 ```bash
 # macOS / Linux
-curl -fsSL https://raw.githubusercontent.com/colbymchenry/codegraph/main/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/colbymchenry/codegraph/main/install.sh \
+  -o /tmp/codegraph-install.sh
+# optional: inspect /tmp/codegraph-install.sh
+sh /tmp/codegraph-install.sh
 ```
 
 ```powershell
 # Windows (PowerShell)
-irm https://raw.githubusercontent.com/colbymchenry/codegraph/main/install.ps1 | iex
+Invoke-WebRequest https://raw.githubusercontent.com/colbymchenry/codegraph/main/install.ps1 `
+  -OutFile codegraph-install.ps1
+# optional: inspect .\codegraph-install.ps1
+.\codegraph-install.ps1
 ```
 
-Initialize indexing at the repository root (once per machine):
+### 2. Wire the MCP server
+
+Installing the CLI alone does not connect your agent. Run:
+
+```bash
+codegraph install
+```
+
+Review any changes it proposes to agent/MCP config (this skill remains the canonical usage guide).
+
+### 3. Initialize indexing
+
+At the repository root (once per clone/machine):
 
 ```bash
 codegraph init
@@ -45,17 +67,25 @@ codegraph --version
 ls .codegraph/
 ```
 
-## Usage
+## Agent Usage
+
+Agents use CodeGraph **only when it is already available**:
+
+- **MCP:** look for a `codegraph_explore` tool among available MCP tools (namespace names vary by environment — match by tool name, not a hard-coded namespace)
+- **CLI:** run `codegraph explore` when `codegraph` is on `PATH` and `.codegraph/` exists
+
+Do **not** download installers, run `codegraph install`, or run `codegraph init` during a task. If neither MCP nor `.codegraph/` is present, use grep/read as usual.
 
 ### MCP tool (preferred in Cursor)
 
-When the `user-codegraph` MCP namespace is available, call `codegraph_explore`:
+When `codegraph_explore` is available:
 
 - One query usually answers symbol location, verbatim source, and call paths
 - Name a file or symbol to load line-numbered source safe for edits
 - If a symbol is listed but deferred, load it by name in a follow-up query
+- If the response flags files as stale since last sync, **Read those files directly** before editing
 
-### Shell CLI (always available after install)
+### Shell CLI
 
 ```bash
 codegraph explore "<symbol names or natural-language question>"
@@ -72,24 +102,25 @@ codegraph explore "how does block cache eviction work"
 
 ```text
 Need to explore / locate code?
-  ├─ .codegraph/ exists OR MCP available?
+  ├─ .codegraph/ exists OR codegraph_explore MCP tool available?
   │    └─ YES → codegraph_explore / codegraph explore
-  │         ├─ Answer sufficient? → done
-  │         └─ Missing detail (config, doc, stale file)? → grep/read that target only
-  └─ NO → grep/read as usual
-       └─ Consider: install + codegraph init for future sessions
+  │         ├─ Answer sufficient and file not stale? → done
+  │         └─ Stale index, local edit, ambiguous symbol, or missing detail?
+  │              → Read the target file(s) directly; grep only if still needed
+  └─ NO → grep/read as usual (do NOT install CodeGraph mid-task)
 ```
 
 ## Anti-patterns
 
-- Running grep or reading many files before trying CodeGraph when the index exists
-- Re-verifying CodeGraph AST results with grep (slower, less accurate on call paths)
+- Running repo-wide grep or reading many files before trying CodeGraph when the index or MCP tool is already available
+- Re-scanning the whole repo with grep after a sufficient `codegraph_explore` hit on the same question
+- Treating CodeGraph output as authoritative after you edited a file, or when explore reports stale/pending sync — **Read the file**
 - Committing `.codegraph/` (gitignored; local only)
-- Skipping `codegraph init` and then ignoring CodeGraph entirely
+- Agents running remote install scripts or `codegraph init` during a task
 
 ## Limitations
 
-- Index lags file writes by ~1 second
+- Index may lag briefly behind file writes (auto-sync debounce; timing varies by machine)
 - Best for source code; configs and markdown may need direct reads
 - Cross-file resolution is name-based; ambiguous symbols may return multiple candidates
 - No compile-time correctness — still run tests and linters after edits

--- a/.agents/skills/cv-codegraph/SKILL.md
+++ b/.agents/skills/cv-codegraph/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: cv-codegraph
+description: Install, initialize, and use CodeGraph for Curvine code exploration. Prefer CodeGraph before grep, find, or manual file reads when locating or understanding code. Use when exploring the codebase, tracing call paths, finding symbols, or when CodeGraph MCP or CLI is available.
+---
+
+# cv-codegraph
+
+[CodeGraph](https://github.com/colbymchenry/codegraph) indexes this repository into a local knowledge graph (`.codegraph/` at repo root). It returns symbol source, call paths (including dynamic-dispatch hops grep cannot follow), and blast-radius context in one call.
+
+## When to Use
+
+- Exploring or locating code in Curvine
+- Tracing how symbols connect across files or crates
+- Answering "where is X" or "how does X work" before opening files
+- Any task where you would reach for `grep`, `find`, or broad file reads
+
+**Priority rule:** When `.codegraph/` exists or the CodeGraph MCP tool is available, use CodeGraph **first**. Fall back to grep/read only when CodeGraph is unavailable, not indexed, or does not cover the target (configs, docs, non-indexed files).
+
+## Setup
+
+Install the CLI if `codegraph` is not on `PATH`:
+
+```bash
+# macOS / Linux
+curl -fsSL https://raw.githubusercontent.com/colbymchenry/codegraph/main/install.sh | sh
+```
+
+```powershell
+# Windows (PowerShell)
+irm https://raw.githubusercontent.com/colbymchenry/codegraph/main/install.ps1 | iex
+```
+
+Initialize indexing at the repository root (once per machine):
+
+```bash
+codegraph init
+```
+
+The `.codegraph/` directory is gitignored and stays local to each developer machine.
+
+Verify:
+
+```bash
+codegraph --version
+ls .codegraph/
+```
+
+## Usage
+
+### MCP tool (preferred in Cursor)
+
+When the `user-codegraph` MCP namespace is available, call `codegraph_explore`:
+
+- One query usually answers symbol location, verbatim source, and call paths
+- Name a file or symbol to load line-numbered source safe for edits
+- If a symbol is listed but deferred, load it by name in a follow-up query
+
+### Shell CLI (always available after install)
+
+```bash
+codegraph explore "<symbol names or natural-language question>"
+```
+
+Examples:
+
+```bash
+codegraph explore "UnifiedFilesystem mount"
+codegraph explore "how does block cache eviction work"
+```
+
+## Decision Flow
+
+```text
+Need to explore / locate code?
+  ├─ .codegraph/ exists OR MCP available?
+  │    └─ YES → codegraph_explore / codegraph explore
+  │         ├─ Answer sufficient? → done
+  │         └─ Missing detail (config, doc, stale file)? → grep/read that target only
+  └─ NO → grep/read as usual
+       └─ Consider: install + codegraph init for future sessions
+```
+
+## Anti-patterns
+
+- Running grep or reading many files before trying CodeGraph when the index exists
+- Re-verifying CodeGraph AST results with grep (slower, less accurate on call paths)
+- Committing `.codegraph/` (gitignored; local only)
+- Skipping `codegraph init` and then ignoring CodeGraph entirely
+
+## Limitations
+
+- Index lags file writes by ~1 second
+- Best for source code; configs and markdown may need direct reads
+- Cross-file resolution is name-based; ambiguous symbols may return multiple candidates
+- No compile-time correctness — still run tests and linters after edits
+
+## Related
+
+- Add or update skills → [cv-add-skills](../cv-add-skills/SKILL.md)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ How to use skills:
 
 Usage notes:
 - For Curvine project workflow tasks, prefer the cv-* skills listed in <available_skills> below
-- **Before grep, find, or reading files to explore code**, read and follow [cv-codegraph](.agents/skills/cv-codegraph/SKILL.md) — prefer CodeGraph (`codegraph_explore` MCP or `codegraph explore` CLI) when `.codegraph/` exists or the MCP tool is available
+- When exploring or locating code, read and follow [cv-codegraph](.agents/skills/cv-codegraph/SKILL.md) — prefer CodeGraph (`codegraph_explore` MCP or `codegraph explore` CLI) when `.codegraph/` exists or the MCP tool is available; **Read source files directly** after local edits or when explore reports stale index sync
 - User-installed global skills (e.g. ~/.cursor/skills/, ~/.claude/skills/) remain available when the agent tool exposes them
 - Do not invent or invoke project skills that are not listed in <available_skills>
 - Do not invoke a skill that is already loaded in your context
@@ -33,7 +33,7 @@ Usage notes:
 
 <skill>
 <name>cv-codegraph</name>
-<description>Install, initialize, and use CodeGraph for Curvine code exploration. Prefer CodeGraph before grep, find, or manual file reads when locating or understanding code. Use when exploring the codebase, tracing call paths, finding symbols, or when CodeGraph MCP or CLI is available.</description>
+<description>Use CodeGraph for Curvine code exploration when the MCP tool or local index is already available; prefer it over repo-wide grep when locating or understanding code. Human one-time setup covers CLI install, MCP wiring, and indexing. Use when exploring the codebase, tracing call paths, or finding symbols.</description>
 <location>project</location>
 </skill>
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ How to use skills:
 
 Usage notes:
 - For Curvine project workflow tasks, prefer the cv-* skills listed in <available_skills> below
+- **Before grep, find, or reading files to explore code**, read and follow [cv-codegraph](.agents/skills/cv-codegraph/SKILL.md) — prefer CodeGraph (`codegraph_explore` MCP or `codegraph explore` CLI) when `.codegraph/` exists or the MCP tool is available
 - User-installed global skills (e.g. ~/.cursor/skills/, ~/.claude/skills/) remain available when the agent tool exposes them
 - Do not invent or invoke project skills that are not listed in <available_skills>
 - Do not invoke a skill that is already loaded in your context
@@ -27,6 +28,12 @@ Usage notes:
 <skill>
 <name>cv-add-skills</name>
 <description>Add or update Curvine cv-* project skills under .agents/skills/, following naming and layout conventions, and sync the AGENTS.md registry. Use when creating a new cv skill, updating an existing cv skill structure, or registering skills after changes.</description>
+<location>project</location>
+</skill>
+
+<skill>
+<name>cv-codegraph</name>
+<description>Install, initialize, and use CodeGraph for Curvine code exploration. Prefer CodeGraph before grep, find, or manual file reads when locating or understanding code. Use when exploring the codebase, tracing call paths, finding symbols, or when CodeGraph MCP or CLI is available.</description>
 <location>project</location>
 </skill>
 
@@ -88,40 +95,3 @@ Usage notes:
 <!-- SKILLS_TABLE_END -->
 
 </skills_system>
-
-<!-- CODEGRAPH_START -->
-## CodeGraph
-
-[CodeGraph](https://github.com/colbymchenry/codegraph) indexes the repository into a local knowledge graph (`.codegraph/` at repo root). Agents should reach for it **before** grep/find or reading files when exploring or locating code.
-
-### Setup
-
-Install CodeGraph if the `codegraph` CLI is not available:
-
-```bash
-# macOS / Linux
-curl -fsSL https://raw.githubusercontent.com/colbymchenry/codegraph/main/install.sh | sh
-```
-
-```powershell
-# Windows (PowerShell)
-irm https://raw.githubusercontent.com/colbymchenry/codegraph/main/install.ps1 | iex
-```
-
-Initialize indexing for this repository (run once at repo root):
-
-```bash
-codegraph init
-```
-
-The `.codegraph/` directory is gitignored and stays local to each developer machine.
-
-### Usage
-
-When `.codegraph/` exists, prefer CodeGraph over manual file search:
-
-- **MCP tool** (when available): `codegraph_explore` answers most code questions in one call — the relevant symbols' verbatim source plus the call paths between them, including dynamic-dispatch hops grep can't follow. Name a file or symbol in the query to read its current line-numbered source. If it's listed but deferred, load it by name via tool search.
-- **Shell** (always works): `codegraph explore "<symbol names or question>"` prints the same output.
-
-If there is no `.codegraph/` directory, skip CodeGraph and fall back to grep/read as usual.
-<!-- CODEGRAPH_END -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,3 +88,40 @@ Usage notes:
 <!-- SKILLS_TABLE_END -->
 
 </skills_system>
+
+<!-- CODEGRAPH_START -->
+## CodeGraph
+
+[CodeGraph](https://github.com/colbymchenry/codegraph) indexes the repository into a local knowledge graph (`.codegraph/` at repo root). Agents should reach for it **before** grep/find or reading files when exploring or locating code.
+
+### Setup
+
+Install CodeGraph if the `codegraph` CLI is not available:
+
+```bash
+# macOS / Linux
+curl -fsSL https://raw.githubusercontent.com/colbymchenry/codegraph/main/install.sh | sh
+```
+
+```powershell
+# Windows (PowerShell)
+irm https://raw.githubusercontent.com/colbymchenry/codegraph/main/install.ps1 | iex
+```
+
+Initialize indexing for this repository (run once at repo root):
+
+```bash
+codegraph init
+```
+
+The `.codegraph/` directory is gitignored and stays local to each developer machine.
+
+### Usage
+
+When `.codegraph/` exists, prefer CodeGraph over manual file search:
+
+- **MCP tool** (when available): `codegraph_explore` answers most code questions in one call — the relevant symbols' verbatim source plus the call paths between them, including dynamic-dispatch hops grep can't follow. Name a file or symbol in the query to read its current line-numbered source. If it's listed but deferred, load it by name via tool search.
+- **Shell** (always works): `codegraph explore "<symbol names or question>"` prints the same output.
+
+If there is no `.codegraph/` directory, skip CodeGraph and fall back to grep/read as usual.
+<!-- CODEGRAPH_END -->


### PR DESCRIPTION
# Summary

Introduce `cv-codegraph` as the canonical guide for CodeGraph setup and usage in Curvine. `AGENTS.md` now only registers the skill and states that agents should prefer CodeGraph before grep/find when exploring code.

# Issue Describe / Design

Documentation-only change. No linked issue.

- **Goal:** Keep `AGENTS.md` lean while giving agents a dedicated, versioned skill for CodeGraph.
- **Design:** Move install/init/usage details into `.agents/skills/cv-codegraph/SKILL.md`; add a prominent usage note in `AGENTS.md` to read `cv-codegraph` before grep-based exploration.
- **Note:** `.codegraph/` remains gitignored — indexing is per-developer local state.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `.agents/skills/cv-codegraph/SKILL.md` | New skill: install, `codegraph init`, MCP/CLI usage, decision flow | None — agent guidance only |
| `AGENTS.md` | Register `cv-codegraph`; add grep-before-CodeGraph usage note; remove inline CodeGraph section | None |
| `.agents/README.md` | Add `cv-codegraph` to skills table | None |
| `.agents/skills/cv-add-skills/SKILL.md` | Add `cv-codegraph` to maintained skill list | None |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| Manual review of skill and registry | PASS | Install commands and priority rule match intent |
| `git check-ignore -v .agents/skills/cv-codegraph/SKILL.md` | PASS | Skill is tracked, not gitignored |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None