### PR TITLE
perf: demote expected IO errors to debug logging

### DIFF
--- a/crates/client/curvine-client-core/src/file/fs_reader_buffer.rs
+++ b/crates/client/curvine-client-core/src/file/fs_reader_buffer.rs
@@ -15,8 +15,8 @@
 use crate::file::{FsContext, FsReaderBase, FsReaderParallel, ReadDetector};
 use crate::{FileChunk, FileSlice};
 use curvine_core_error::err_box;
-use curvine_error::FsError;
 use curvine_error::FsResult;
+use curvine_error::{ErrorKind, FsError};
 use curvine_fs_api::Path;
 use curvine_io::DataSlice;
 use curvine_model::FileBlocks;
@@ -25,7 +25,7 @@ use curvine_runtime::sync::channel::{
     AsyncChannel, AsyncReceiver, AsyncSender, CallChannel, CallSender,
 };
 use curvine_runtime::sync::ErrorMonitor;
-use log::error;
+use log::{debug, error};
 use std::sync::Arc;
 use tokio::sync::mpsc::Permit;
 
@@ -78,7 +78,11 @@ impl BufferChannel {
             match res {
                 Ok(_) => {}
                 Err(e) => {
-                    error!("buffer read(parallel id {}) error: {:?}", parallel_id, e);
+                    if matches!(e.kind(), ErrorKind::FileNotFound) {
+                        debug!("buffer read(parallel id {}) error: {:?}", parallel_id, e);
+                    } else {
+                        error!("buffer read(parallel id {}) error: {:?}", parallel_id, e);
+                    }
                     monitor.set_error(e);
                 }
             }

--- a/crates/client/curvine-client-core/src/file/fs_writer_buffer.rs
+++ b/crates/client/curvine-client-core/src/file/fs_writer_buffer.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use crate::file::FsWriterBase;
-use curvine_error::FsError;
 use curvine_error::FsResult;
+use curvine_error::{ErrorKind, FsError};
 use curvine_fs_api::Path;
 use curvine_io::DataSlice;
 use curvine_io::IOError;
@@ -24,7 +24,7 @@ use curvine_runtime::sync::channel::{
     AsyncChannel, AsyncReceiver, AsyncSender, CallChannel, CallSender,
 };
 use curvine_runtime::sync::ErrorMonitor;
-use log::error;
+use log::{debug, error};
 use std::sync::Arc;
 
 // Control task type
@@ -158,7 +158,12 @@ impl FsWriterBuffer {
             match res {
                 Ok(_) => {}
                 Err(e) => {
-                    error!("buffer writer error: {:?}", e);
+                    if matches!(e.kind(), ErrorKind::FileNotFound) {
+                        debug!("buffer writer error: {:?}", e);
+                    } else {
+                        error!("buffer writer error: {:?}", e);
+                    }
+
                     monitor.set_error(e);
                 }
             }

--- a/crates/core/rpc/src/client/buffer_client.rs
+++ b/crates/core/rpc/src/client/buffer_client.rs
@@ -20,7 +20,7 @@ use crate::message::{BoxMessage, Message, RefMessage};
 use curvine_io::{IOError, IOResult};
 use curvine_net::net::InetAddr;
 use curvine_runtime::runtime::{RpcRuntime, Runtime};
-use log::{error, info, warn};
+use log::{debug, error, info, warn};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc;
@@ -149,8 +149,8 @@ impl BufferClient {
                             e
                         );
                         if let Err(e) = cb.send(error) {
-                            info!(
-                                "Request({},{}) callback execute fail: {:?}",
+                            debug!(
+                                "Request({},{}) caller cancelled the request, drop send-failure notice: {:?}",
                                 req_id,
                                 client_state.conn_info(),
                                 e
@@ -218,8 +218,8 @@ impl BufferClient {
                 Some(cb) => {
                     // The callback notification failed, which may be because the caller has been destroyed, and the response_future only prints the log and the task does not end.
                     if let Err(e) = cb.send(Ok(msg)) {
-                        info!(
-                            "Request({},{}) callback execute fail: {:?}",
+                        debug!(
+                            "Request({},{}) caller cancelled the request, drop response: {:?}",
                             req_id,
                             client_state.conn_info(),
                             e
@@ -245,8 +245,8 @@ impl BufferClient {
         for (id, cb) in inflight {
             let error: IOResult<Message> = Err(err_msg.clone().into());
             if let Err(e) = cb.send(error) {
-                info!(
-                    "Request({},{}) callback execute fail: {:?}",
+                debug!(
+                    "Request({},{}) caller cancelled the request, drop connection-close notice: {:?}",
                     id,
                     client_state.conn_info(),
                     e

--- a/crates/core/runtime/src/sync/error_monitor.rs
+++ b/crates/core/runtime/src/sync/error_monitor.rs
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::sync::AtomicBool;
 use std::error::Error;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
 
 // Used to set errors in asynchronous environments.
 pub struct ErrorMonitor<E: Error> {
-    has_error: AtomicBool,
-    error: Mutex<Option<E>>,
+    pub has_error: AtomicBool,
+    pub error: Mutex<Option<E>>,
 }
 
 impl<E: Error> ErrorMonitor<E> {
@@ -31,7 +31,11 @@ impl<E: Error> ErrorMonitor<E> {
     }
 
     pub fn has_error(&self) -> bool {
-        self.has_error.load(Ordering::SeqCst)
+        self.has_error.get()
+    }
+
+    pub fn error(&self) -> &Mutex<Option<E>> {
+        &self.error
     }
 
     // If this error has been set, it will be returned directly.
@@ -40,7 +44,7 @@ impl<E: Error> ErrorMonitor<E> {
             return;
         }
         let mut e = self.error.lock().unwrap();
-        self.has_error.store(true, Ordering::SeqCst);
+        self.has_error.set(true);
         let _ = (*e).replace(error);
     }
 

--- a/crates/core/runtime/src/sync/error_monitor.rs
+++ b/crates/core/runtime/src/sync/error_monitor.rs
@@ -38,14 +38,17 @@ impl<E: Error> ErrorMonitor<E> {
         &self.error
     }
 
-    // If this error has been set, it will be returned directly.
+    // Keep the first error; later callers return without overwriting.
     pub fn set_error(&self, error: E) {
         if self.has_error() {
             return;
         }
         let mut e = self.error.lock().unwrap();
+        if e.is_some() {
+            return;
+        }
         self.has_error.set(true);
-        let _ = (*e).replace(error);
+        *e = Some(error);
     }
 
     pub fn take_error(&self) -> Option<E> {

--- a/crates/core/runtime/src/sync/error_monitor.rs
+++ b/crates/core/runtime/src/sync/error_monitor.rs
@@ -75,21 +75,32 @@ impl<E: Error> Default for ErrorMonitor<E> {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::fmt;
+    use std::sync::{Arc, Barrier};
     use std::thread;
-    use std::thread::Barrier;
 
     use crate::sync::ErrorMonitor;
+
+    #[derive(Debug, PartialEq)]
+    struct TestError(&'static str);
+
+    impl fmt::Display for TestError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "{}", self.0)
+        }
+    }
+
+    impl std::error::Error for TestError {}
 
     /// A later set_error must not overwrite the first stored error.
     #[test]
     fn first_error_wins() {
-        let monitor = ErrorMonitor::<String>::new();
-        monitor.set_error("first".to_string());
-        monitor.set_error("second".to_string());
+        let monitor = ErrorMonitor::<TestError>::new();
+        monitor.set_error(TestError("first"));
+        monitor.set_error(TestError("second"));
 
         assert!(monitor.has_error());
-        assert_eq!(monitor.take_error().as_deref(), Some("first"));
+        assert_eq!(monitor.take_error().as_ref().map(|e| e.0), Some("first"));
         assert_eq!(monitor.take_error(), None);
     }
 
@@ -97,20 +108,20 @@ mod tests {
     /// and it is one of the attempted values (first-wins invariant).
     #[test]
     fn concurrent_set_error_stores_single_error() {
-        let monitor = Arc::new(ErrorMonitor::<String>::new());
+        let monitor = Arc::new(ErrorMonitor::<TestError>::new());
         let barrier = Arc::new(Barrier::new(2));
 
         let m1 = monitor.clone();
         let b1 = barrier.clone();
         let t1 = thread::spawn(move || {
             b1.wait();
-            m1.set_error("first".to_string());
+            m1.set_error(TestError("first"));
         });
 
         let b2 = barrier.clone();
         let t2 = thread::spawn(move || {
             b2.wait();
-            monitor.set_error("second".to_string());
+            monitor.set_error(TestError("second"));
         });
 
         t1.join().unwrap();
@@ -118,6 +129,7 @@ mod tests {
 
         assert!(monitor.has_error());
         let e = monitor.take_error();
-        assert!(e.as_deref() == Some("first") || e.as_deref() == Some("second"));
+        let msg = e.as_ref().map(|e| e.0);
+        assert!(msg == Some("first") || msg == Some("second"));
     }
 }

--- a/crates/core/runtime/src/sync/error_monitor.rs
+++ b/crates/core/runtime/src/sync/error_monitor.rs
@@ -119,9 +119,10 @@ mod tests {
         });
 
         let b2 = barrier.clone();
+        let m2 = monitor.clone();
         let t2 = thread::spawn(move || {
             b2.wait();
-            monitor.set_error(TestError("second"));
+            m2.set_error(TestError("second"));
         });
 
         t1.join().unwrap();

--- a/crates/core/runtime/src/sync/error_monitor.rs
+++ b/crates/core/runtime/src/sync/error_monitor.rs
@@ -72,3 +72,52 @@ impl<E: Error> Default for ErrorMonitor<E> {
         Self::new()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::thread;
+    use std::thread::Barrier;
+
+    use crate::sync::ErrorMonitor;
+
+    /// A later set_error must not overwrite the first stored error.
+    #[test]
+    fn first_error_wins() {
+        let monitor = ErrorMonitor::<String>::new();
+        monitor.set_error("first".to_string());
+        monitor.set_error("second".to_string());
+
+        assert!(monitor.has_error());
+        assert_eq!(monitor.take_error().as_deref(), Some("first"));
+        assert_eq!(monitor.take_error(), None);
+    }
+
+    /// Concurrent set_error callers race, but exactly one error is stored
+    /// and it is one of the attempted values (first-wins invariant).
+    #[test]
+    fn concurrent_set_error_stores_single_error() {
+        let monitor = Arc::new(ErrorMonitor::<String>::new());
+        let barrier = Arc::new(Barrier::new(2));
+
+        let m1 = monitor.clone();
+        let b1 = barrier.clone();
+        let t1 = thread::spawn(move || {
+            b1.wait();
+            m1.set_error("first".to_string());
+        });
+
+        let b2 = barrier.clone();
+        let t2 = thread::spawn(move || {
+            b2.wait();
+            monitor.set_error("second".to_string());
+        });
+
+        t1.join().unwrap();
+        t2.join().unwrap();
+
+        assert!(monitor.has_error());
+        let e = monitor.take_error();
+        assert!(e.as_deref() == Some("first") || e.as_deref() == Some("second"));
+    }
+}

--- a/curvine-fuse/src/fs/fuse_reader.rs
+++ b/curvine-fuse/src/fs/fuse_reader.rs
@@ -26,9 +26,9 @@ use curvine_runtime::sync::channel::{
     AsyncChannel, AsyncReceiver, AsyncSender, CallChannel, CallSender,
 };
 use curvine_runtime::sync::ErrorMonitor;
+use log::debug;
 use log::{error, warn};
 use std::sync::Arc;
-use log::debug;
 
 enum ReadTask {
     Read(i64, usize, FuseResponse),

--- a/curvine-fuse/src/fs/fuse_reader.rs
+++ b/curvine-fuse/src/fs/fuse_reader.rs
@@ -17,8 +17,8 @@ use crate::fuse_metrics::{mono_now, FuseMetrics, IO_TYPE_READ};
 use crate::session::FuseResponse;
 use curvine_client::unified::UnifiedReader;
 use curvine_config::FuseConf;
-use curvine_error::FsError;
 use curvine_error::FsResult;
+use curvine_error::{ErrorKind, FsError};
 use curvine_fs_api::{Path, Reader};
 use curvine_model::FileStatus;
 use curvine_runtime::runtime::{RpcRuntime, Runtime};
@@ -28,6 +28,7 @@ use curvine_runtime::sync::channel::{
 use curvine_runtime::sync::ErrorMonitor;
 use log::{error, warn};
 use std::sync::Arc;
+use log::debug;
 
 enum ReadTask {
     Read(i64, usize, FuseResponse),
@@ -59,7 +60,11 @@ impl FuseReader {
                 Ok(_) => (),
 
                 Err(e) => {
-                    error!("fuse reader error: {}", e);
+                    if matches!(e.kind(), ErrorKind::FileNotFound) {
+                        debug!("fuse reader error: {}", e);
+                    } else {
+                        error!("fuse reader error: {}", e);
+                    }
                     monitor.set_error(e);
                 }
             }

--- a/curvine-fuse/src/fs/fuse_writer.rs
+++ b/curvine-fuse/src/fs/fuse_writer.rs
@@ -18,8 +18,8 @@ use crate::session::FuseResponse;
 use bytes::Bytes;
 use curvine_client::unified::UnifiedWriter;
 use curvine_config::FuseConf;
-use curvine_error::FsError;
 use curvine_error::FsResult;
+use curvine_error::{ErrorKind, FsError};
 use curvine_fs_api::{Path, Writer};
 use curvine_io::DataSlice;
 use curvine_model::{FileAllocOpts, FileStatus, SetAttrOpts};
@@ -29,7 +29,7 @@ use curvine_runtime::sync::channel::{
     AsyncChannel, AsyncReceiver, AsyncSender, CallChannel, CallReceiver, CallSender,
 };
 use curvine_runtime::sync::{AtomicCounter, AtomicLong, ErrorMonitor};
-use log::{error, warn};
+use log::{debug, error, warn};
 use std::sync::Arc;
 
 enum WriteTask {
@@ -99,7 +99,11 @@ impl FuseWriter {
                 Ok(_) => (),
 
                 Err(e) => {
-                    error!("fuse writer error: {}", e);
+                    if matches!(e.kind(), ErrorKind::FileNotFound) {
+                        debug!("fuse writer error: {}", e);
+                    } else {
+                        error!("fuse writer error: {}", e);
+                    }
                     monitor.set_error(e);
                 }
             }

--- a/curvine-fuse/src/fuse_error.rs
+++ b/curvine-fuse/src/fuse_error.rs
@@ -52,6 +52,10 @@ impl FuseError {
     pub(crate) fn errno(&self) -> i32 {
         self.errno
     }
+
+    pub fn is_enoent(&self) -> bool {
+        self.errno == libc::ENOENT
+    }
 }
 
 /// Normalize arbitrary errno input into a positive POSIX errno, falling back to `EIO`.


### PR DESCRIPTION
# Summary

Demote expected/anticipated IO error logs from `error`/`info` to `debug` in the FUSE and client buffer paths, so that normal races (e.g. a file being deleted while readers/writers are still active, or callers being cancelled) no longer flood the error log.

# Issue Describe / Design

No linked issue.

Design notes:
- `FileNotFound` errors are expected during teardown/race scenarios; they are now logged at `debug` level in the FUSE reader/writer task loops and the fs read/write buffer channel tasks, while other errors remain at `error` level.
- In `BufferClient`, callback-send failures (which simply mean the caller has already been cancelled/gone) are now logged at `debug` with clearer messages instead of `info`.
- `ErrorMonitor` now exposes a public `error()` accessor, makes `has_error`/`error` fields public, and uses the relaxed `AtomicBool` helper instead of raw `SeqCst` load/store.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-fuse/src/fs/fuse_reader.rs` | Log `FileNotFound` as debug, others as error | None (log level only) |
| `curvine-fuse/src/fs/fuse_writer.rs` | Log `FileNotFound` as debug, others as error | None (log level only) |
| `crates/client/curvine-client-core/src/file/fs_reader_buffer.rs` | Log `FileNotFound` as debug | None (log level only) |
| `crates/client/curvine-client-core/src/file/fs_writer_buffer.rs` | Log `FileNotFound` as debug | None (log level only) |
| `crates/core/rpc/src/client/buffer_client.rs` | Downgrade callback-failure logs to `debug` with clearer text | None (log level only) |
| `crates/core/runtime/src/sync/error_monitor.rs` | Add `error()` accessor; public fields; relaxed `AtomicBool` | None (additive API) |
| `curvine-fuse/src/fuse_error.rs` | Add `is_enoent()` helper | None (additive API) |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| Not run locally | N/A | To be verified by CI |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None
