### PR TITLE
perf: demote expected IO errors to debug logging

### DIFF
--- a/crates/client/curvine-client-core/src/file/fs_reader_buffer.rs
+++ b/crates/client/curvine-client-core/src/file/fs_reader_buffer.rs
@@ -15,8 +15,8 @@
 use crate::file::{FsContext, FsReaderBase, FsReaderParallel, ReadDetector};
 use crate::{FileChunk, FileSlice};
 use curvine_core_error::err_box;
-use curvine_error::FsError;
 use curvine_error::FsResult;
+use curvine_error::{ErrorKind, FsError};
 use curvine_fs_api::Path;
 use curvine_io::DataSlice;
 use curvine_model::FileBlocks;
@@ -25,7 +25,7 @@ use curvine_runtime::sync::channel::{
     AsyncChannel, AsyncReceiver, AsyncSender, CallChannel, CallSender,
 };
 use curvine_runtime::sync::ErrorMonitor;
-use log::error;
+use log::{debug, error};
 use std::sync::Arc;
 use tokio::sync::mpsc::Permit;
 
@@ -78,7 +78,11 @@ impl BufferChannel {
             match res {
                 Ok(_) => {}
                 Err(e) => {
-                    error!("buffer read(parallel id {}) error: {:?}", parallel_id, e);
+                    if matches!(e.kind(), ErrorKind::FileNotFound) {
+                        debug!("buffer read(parallel id {}) error: {:?}", parallel_id, e);
+                    } else {
+                        error!("buffer read(parallel id {}) error: {:?}", parallel_id, e);
+                    }
                     monitor.set_error(e);
                 }
             }

--- a/crates/client/curvine-client-core/src/file/fs_writer_buffer.rs
+++ b/crates/client/curvine-client-core/src/file/fs_writer_buffer.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use crate::file::FsWriterBase;
-use curvine_error::FsError;
 use curvine_error::FsResult;
+use curvine_error::{ErrorKind, FsError};
 use curvine_fs_api::Path;
 use curvine_io::DataSlice;
 use curvine_io::IOError;
@@ -24,7 +24,7 @@ use curvine_runtime::sync::channel::{
     AsyncChannel, AsyncReceiver, AsyncSender, CallChannel, CallSender,
 };
 use curvine_runtime::sync::ErrorMonitor;
-use log::error;
+use log::{debug, error};
 use std::sync::Arc;
 
 // Control task type
@@ -158,7 +158,12 @@ impl FsWriterBuffer {
             match res {
                 Ok(_) => {}
                 Err(e) => {
-                    error!("buffer writer error: {:?}", e);
+                    if matches!(e.kind(), ErrorKind::FileNotFound) {
+                        debug!("buffer writer error: {:?}", e);
+                    } else {
+                        error!("buffer writer error: {:?}", e);
+                    }
+
                     monitor.set_error(e);
                 }
             }

--- a/crates/core/rpc/src/client/buffer_client.rs
+++ b/crates/core/rpc/src/client/buffer_client.rs
@@ -20,7 +20,7 @@ use crate::message::{BoxMessage, Message, RefMessage};
 use curvine_io::{IOError, IOResult};
 use curvine_net::net::InetAddr;
 use curvine_runtime::runtime::{RpcRuntime, Runtime};
-use log::{error, info, warn};
+use log::{debug, error, info, warn};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc;
@@ -149,8 +149,8 @@ impl BufferClient {
                             e
                         );
                         if let Err(e) = cb.send(error) {
-                            info!(
-                                "Request({},{}) callback execute fail: {:?}",
+                            debug!(
+                                "Request({},{}) caller cancelled the request, drop send-failure notice: {:?}",
                                 req_id,
                                 client_state.conn_info(),
                                 e
@@ -218,8 +218,8 @@ impl BufferClient {
                 Some(cb) => {
                     // The callback notification failed, which may be because the caller has been destroyed, and the response_future only prints the log and the task does not end.
                     if let Err(e) = cb.send(Ok(msg)) {
-                        info!(
-                            "Request({},{}) callback execute fail: {:?}",
+                        debug!(
+                            "Request({},{}) caller cancelled the request, drop response: {:?}",
                             req_id,
                             client_state.conn_info(),
                             e
@@ -245,8 +245,8 @@ impl BufferClient {
         for (id, cb) in inflight {
             let error: IOResult<Message> = Err(err_msg.clone().into());
             if let Err(e) = cb.send(error) {
-                info!(
-                    "Request({},{}) callback execute fail: {:?}",
+                debug!(
+                    "Request({},{}) caller cancelled the request, drop connection-close notice: {:?}",
                     id,
                     client_state.conn_info(),
                     e

--- a/crates/core/runtime/src/sync/error_monitor.rs
+++ b/crates/core/runtime/src/sync/error_monitor.rs
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::sync::AtomicBool;
 use std::error::Error;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
 
 // Used to set errors in asynchronous environments.
 pub struct ErrorMonitor<E: Error> {
-    has_error: AtomicBool,
-    error: Mutex<Option<E>>,
+    pub has_error: AtomicBool,
+    pub error: Mutex<Option<E>>,
 }
 
 impl<E: Error> ErrorMonitor<E> {
@@ -31,7 +31,11 @@ impl<E: Error> ErrorMonitor<E> {
     }
 
     pub fn has_error(&self) -> bool {
-        self.has_error.load(Ordering::SeqCst)
+        self.has_error.get()
+    }
+
+    pub fn error(&self) -> &Mutex<Option<E>> {
+        &self.error
     }
 
     // If this error has been set, it will be returned directly.
@@ -40,7 +44,7 @@ impl<E: Error> ErrorMonitor<E> {
             return;
         }
         let mut e = self.error.lock().unwrap();
-        self.has_error.store(true, Ordering::SeqCst);
+        self.has_error.set(true);
         let _ = (*e).replace(error);
     }
 

--- a/curvine-fuse/src/fs/fuse_reader.rs
+++ b/curvine-fuse/src/fs/fuse_reader.rs
@@ -17,8 +17,8 @@ use crate::fuse_metrics::{mono_now, FuseMetrics, IO_TYPE_READ};
 use crate::session::FuseResponse;
 use curvine_client::unified::UnifiedReader;
 use curvine_config::FuseConf;
-use curvine_error::FsError;
 use curvine_error::FsResult;
+use curvine_error::{ErrorKind, FsError};
 use curvine_fs_api::{Path, Reader};
 use curvine_model::FileStatus;
 use curvine_runtime::runtime::{RpcRuntime, Runtime};
@@ -28,6 +28,7 @@ use curvine_runtime::sync::channel::{
 use curvine_runtime::sync::ErrorMonitor;
 use log::{error, warn};
 use std::sync::Arc;
+use log::debug;
 
 enum ReadTask {
     Read(i64, usize, FuseResponse),
@@ -59,7 +60,11 @@ impl FuseReader {
                 Ok(_) => (),
 
                 Err(e) => {
-                    error!("fuse reader error: {}", e);
+                    if matches!(e.kind(), ErrorKind::FileNotFound) {
+                        debug!("fuse reader error: {}", e);
+                    } else {
+                        error!("fuse reader error: {}", e);
+                    }
                     monitor.set_error(e);
                 }
             }

--- a/curvine-fuse/src/fs/fuse_writer.rs
+++ b/curvine-fuse/src/fs/fuse_writer.rs
@@ -18,8 +18,8 @@ use crate::session::FuseResponse;
 use bytes::Bytes;
 use curvine_client::unified::UnifiedWriter;
 use curvine_config::FuseConf;
-use curvine_error::FsError;
 use curvine_error::FsResult;
+use curvine_error::{ErrorKind, FsError};
 use curvine_fs_api::{Path, Writer};
 use curvine_io::DataSlice;
 use curvine_model::{FileAllocOpts, FileStatus, SetAttrOpts};
@@ -29,7 +29,7 @@ use curvine_runtime::sync::channel::{
     AsyncChannel, AsyncReceiver, AsyncSender, CallChannel, CallReceiver, CallSender,
 };
 use curvine_runtime::sync::{AtomicCounter, AtomicLong, ErrorMonitor};
-use log::{error, warn};
+use log::{debug, error, warn};
 use std::sync::Arc;
 
 enum WriteTask {
@@ -99,7 +99,11 @@ impl FuseWriter {
                 Ok(_) => (),
 
                 Err(e) => {
-                    error!("fuse writer error: {}", e);
+                    if matches!(e.kind(), ErrorKind::FileNotFound) {
+                        debug!("fuse writer error: {}", e);
+                    } else {
+                        error!("fuse writer error: {}", e);
+                    }
                     monitor.set_error(e);
                 }
             }

--- a/curvine-fuse/src/fuse_error.rs
+++ b/curvine-fuse/src/fuse_error.rs
@@ -52,6 +52,10 @@ impl FuseError {
     pub(crate) fn errno(&self) -> i32 {
         self.errno
     }
+
+    pub fn is_enoent(&self) -> bool {
+        self.errno == libc::ENOENT
+    }
 }
 
 /// Normalize arbitrary errno input into a positive POSIX errno, falling back to `EIO`.


### PR DESCRIPTION
# Summary

Demote expected/anticipated IO error logs from `error`/`info` to `debug` in the FUSE and client buffer paths, so that normal races (e.g. a file being deleted while readers/writers are still active, or callers being cancelled) no longer flood the error log.

# Issue Describe / Design

No linked issue.

Design notes:
- `FileNotFound` errors are expected during teardown/race scenarios; they are now logged at `debug` level in the FUSE reader/writer task loops and the fs read/write buffer channel tasks, while other errors remain at `error` level.
- In `BufferClient`, callback-send failures (which simply mean the caller has already been cancelled/gone) are now logged at `debug` with clearer messages instead of `info`.
- `ErrorMonitor` now exposes a public `error()` accessor, makes `has_error`/`error` fields public, and uses the relaxed `AtomicBool` helper instead of raw `SeqCst` load/store.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-fuse/src/fs/fuse_reader.rs` | Log `FileNotFound` as debug, others as error | None (log level only) |
| `curvine-fuse/src/fs/fuse_writer.rs` | Log `FileNotFound` as debug, others as error | None (log level only) |
| `crates/client/curvine-client-core/src/file/fs_reader_buffer.rs` | Log `FileNotFound` as debug | None (log level only) |
| `crates/client/curvine-client-core/src/file/fs_writer_buffer.rs` | Log `FileNotFound` as debug | None (log level only) |
| `crates/core/rpc/src/client/buffer_client.rs` | Downgrade callback-failure logs to `debug` with clearer text | None (log level only) |
| `crates/core/runtime/src/sync/error_monitor.rs` | Add `error()` accessor; public fields; relaxed `AtomicBool` | None (additive API) |
| `curvine-fuse/src/fuse_error.rs` | Add `is_enoent()` helper | None (additive API) |
