### PR TITLE
fix(client): commit blocks parked in cache_writers before append

### DIFF
--- a/crates/client/curvine-client-core/src/file/fs_writer_base.rs
+++ b/crates/client/curvine-client-core/src/file/fs_writer_base.rs
@@ -302,37 +302,32 @@ impl FsWriterBase {
         }
     }
 
-    async fn complete0(
-        &mut self,
-        only_flush: bool,
-        set_attr_opts: Option<SetAttrOpts>,
-    ) -> FsResult<Option<FileBlocks>> {
+    async fn commit_all_pending_writers(&mut self) -> FsResult<()> {
         if let Some(writer) = self.cur_writer.take() {
             self.cache_writers.insert(writer.block_id(), writer);
         };
 
         let mut writer_commits = Vec::with_capacity(self.cache_writers.len());
         for (_, writer) in self.cache_writers.iter_mut() {
-            // Always finalize on the worker. `only_flush` only keeps the master
-            // write lease open; it must still publish block data.
-            //
-            // A prior resize/flush may already have finalized an older
-            // generation. Later writes reopen as a staging rewrite while
-            // `get_readable_block` prefers the committed generation. Calling
-            // `flush()` here without `complete()` leaves that rewrite
-            // unpublished, so FUSE dirty-read / LTP ftest/pwrite see EIO or
-            // stale holes after sparse write-then-read.
             let commit_block = writer.complete().await?;
             writer_commits.push(commit_block);
         }
 
+        self.cache_writers.clear();
+
         for commit in writer_commits {
-            self.file_blocks.add_commit(commit)?;
+            self.add_durable_commit(commit)?;
         }
 
-        // `complete()` ends the worker write session; drop handles so the next
-        // write reopens against the newly published generation.
-        self.cache_writers.clear();
+        Ok(())
+    }
+
+    async fn complete0(
+        &mut self,
+        only_flush: bool,
+        set_attr_opts: Option<SetAttrOpts>,
+    ) -> FsResult<Option<FileBlocks>> {
+        self.commit_all_pending_writers().await?;
 
         let commit_blocks = self.file_blocks.take_commit_blocks();
         // From this point onward a request may have reached the master even if
@@ -412,7 +407,7 @@ impl FsWriterBase {
                     }
 
                     None => {
-                        self.update_writer(None, false).await?;
+                        self.commit_all_pending_writers().await?;
 
                         let commit_blocks = self.file_blocks.take_commit_blocks();
                         let last_block = self.file_blocks.last_block();

--- a/curvine-tests/tests/fs_test.rs
+++ b/curvine-tests/tests/fs_test.rs
@@ -53,6 +53,17 @@ fn test_filesystem_end_to_end_operations_on_cluster() -> FsResult<()> {
     override_conf.client.short_circuit = true;
     test_file_block_size_override(&testing, &rt, override_conf)?;
 
+    // Regression: append must commit blocks parked in cache_writers, else the
+    // master's compute_len() != self.len check fails with EIO. block_size = 1KB
+    // makes a hole + append cross block boundaries quickly.
+    let mut append_conf = conf.clone();
+    append_conf.client.block_size = 1024;
+    append_conf.client.block_size_str = "1024B".to_string();
+    append_conf.client.max_cache_block_handles = 4;
+    append_conf.client.short_circuit = false;
+    append_conf.client.replicas = 1;
+    test_append_commits_cached_blocks(&testing, &rt, append_conf)?;
+
     // Test short_circuit = false
     conf.client.short_circuit = false;
     run_filesystem_end_to_end_operations_on_cluster(&testing, &rt, conf.clone())?;
@@ -98,6 +109,69 @@ fn test_file_block_size_override(
 
         assert_eq!(read, data.len());
         assert_eq!(actual.as_ref(), data.as_slice());
+        Ok(())
+    })
+}
+
+/// Regression: appending a new block must first commit blocks parked in
+/// `cache_writers`; otherwise their bytes count toward the client's `self.len`
+/// but stay out of `commit_blocks`, and the master's `compute_len() != self.len`
+/// check fails with EIO ("Complete len is not equal to file len").
+fn test_append_commits_cached_blocks(
+    testing: &Testing,
+    rt: &Arc<AsyncRuntime>,
+    conf: ClusterConf,
+) -> FsResult<()> {
+    let fs = testing.get_fs(Some(rt.clone()), Some(conf))?;
+
+    rt.block_on(async move {
+        let path = Path::from_str("/fs_test/append_omit_uncommitted_cache_block.log")?;
+        let bs = 1024i64;
+        let mut writer = fs.create(&path, true).await?;
+
+        // Write 1K at offset 1K: creates a [0,1K) hole (block0, with_alloc) and
+        // block1 (with_pre, uncommitted). seek(0) drains the writes and parks
+        // block1 into cache_writers.
+        writer.seek(bs).await?;
+        writer.write(&vec![0xAAu8; bs as usize]).await?;
+        writer.seek(0).await?;
+
+        // Seek to EOF (2K): cur_writer becomes None, cache_writers keeps block1.
+        writer.seek(2 * bs).await?;
+
+        // Append at EOF and complete: the append path requests block2 and must
+        // commit block1 first, otherwise the master rejects the length.
+        writer.write(&vec![0xBBu8; 16]).await?;
+        writer.complete().await?;
+
+        // [0,1K)=hole, [1K,2K)=0xAA, [2K,+16)=0xBB.
+        let total = (2 * bs + 16) as usize;
+        let hole = bs as usize;
+        let body = (2 * bs) as usize;
+        let mut reader = fs.open(&path).await?;
+        reader.seek(0).await?;
+        let mut buf = vec![0u8; total];
+        let n = reader.read_full(&mut buf).await?;
+        reader.complete().await?;
+
+        assert_eq!(n, total, "short read: expected {} got {}", total, n);
+        assert!(
+            buf[..hole].iter().all(|&b| b == 0),
+            "hole [0,{}) must be zeros",
+            hole
+        );
+        assert!(
+            buf[hole..body].iter().all(|&b| b == 0xAA),
+            "block1 [{},{}) should be 0xAA",
+            hole,
+            body
+        );
+        assert!(
+            buf[body..].iter().all(|&b| b == 0xBB),
+            "appended block2 [{},{}) should be 0xBB",
+            body,
+            total
+        );
         Ok(())
     })
 }


### PR DESCRIPTION
# Summary

Appending a new block skipped committing blocks parked in `cache_writers`,
causing `complete()` to fail with EIO ("Complete len is not equal to file len")
on sparse files (hole + write + complete). This PR extracts a single commit
choke point and funnels all len-publishing paths through it.

# Issue Describe / Design

Reproduction: create a file, seek past EOF and write a block, seek back (the
written block is parked in `cache_writers`, uncommitted), seek to the new EOF,
then append and complete.

- **Root cause**: `get_writer()`'s append branch called `update_writer(None, false)`,
  a no-op when `cur_writer` is `None` that never commits blocks parked in
  `cache_writers`. `take_commit_blocks()` therefore returned nothing for those
  blocks, while `add_block_by_id(self.len, ..)` already counted their bytes.
  On the master, `acquire_new_block -> complete()` computes
  `compute_len() = sum(block.len)`; the omitted `with_pre` block still had
  `len = 0`, so `compute_len != self.len` failed with EIO.
- **Fix approach**: extract `commit_all_pending_writers()`, which finalizes
  `cur_writer` plus all `cache_writers` and records their commits as durable;
  funnel the append, `complete0` and `resize` paths through it. It is purely
  local (no master RPC); resize keeps `complete()` because the resize RPC
  carries no `commit_blocks` and its Step 4 replaces `file_blocks` wholesale.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `crates/client/curvine-client-core/src/file/fs_writer_base.rs` | Add `commit_all_pending_writers()`; the append branch commits all in-flight writers; `complete0` funnels through it | Sequential writes unchanged (empty `cache_writers`); random-write worker finalize RPC count is conserved, only timed earlier |
| `curvine-tests/tests/fs_test.rs` | Add regression `test_append_commits_cached_blocks` (block_size = 1KB, hole + park + append) | None (new case in existing cluster test) |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test -p curvine-tests --test fs_test` | PASS | Failed with `complete_len = 1024, file_len = 2048` before the fix; passes with full data verification after |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None
