### PR TITLE
refactor(metrics): remove redundant used_memory_bytes gauges (#1656)

### DIFF
--- a/curvine-fuse/src/fuse_metrics.rs
+++ b/curvine-fuse/src/fuse_metrics.rs
@@ -151,7 +151,6 @@ pub struct FuseMetrics {
     pub inode_num: Gauge,
     pub file_handle_num: Gauge,
     pub dir_handle_num: Gauge,
-    pub fuse_used_memory_bytes: Gauge,
 
     pub write_back_active_inode_num: Gauge,
     pub write_back_mem_usage: Gauge,
@@ -253,7 +252,6 @@ impl FuseMetrics {
             inode_num: m::new_gauge("inode_num", "FUSE inode count in dcache")?,
             file_handle_num: m::new_gauge("file_handle_num", "FUSE open file handle count")?,
             dir_handle_num: m::new_gauge("dir_handle_num", "FUSE open directory handle count")?,
-            fuse_used_memory_bytes: m::new_gauge("fuse_used_memory_bytes", "Total memory used")?,
             write_back_active_inode_num: m::new_gauge(
                 "write_back_active_inode_num",
                 "FUSE write-back active inode count",

--- a/curvine-master/src/master/master_metrics.rs
+++ b/curvine-master/src/master/master_metrics.rs
@@ -21,7 +21,6 @@ use curvine_core_error::CommonResult;
 use curvine_metrics::{Counter, CounterVec, Gauge, GaugeVec, HistogramVec, Metrics, Metrics as m};
 use curvine_model::MetricValue;
 use curvine_runtime::sync::FastDashMap;
-use curvine_sys::SysUtils;
 use log::{debug, info, warn};
 use std::fmt::{Debug, Formatter};
 
@@ -48,7 +47,6 @@ pub struct MasterMetrics {
     pub(crate) journal_applied: Gauge,
     pub(crate) journal_ufs_applied: Gauge,
 
-    pub(crate) used_memory_bytes: Gauge,
     pub(crate) rocksdb_metrics: GaugeVec,
 
     pub(crate) inode_dir_num: Gauge,
@@ -142,7 +140,6 @@ impl MasterMetrics {
                 "Last UFS-applied index of the journal state machine",
             )?,
 
-            used_memory_bytes: m::new_gauge("used_memory_bytes", "Total memory used")?,
             rocksdb_metrics: m::new_gauge_vec("rocksdb_metrics", "RocksDB metrics", &["tag"])?,
 
             inode_dir_num: m::new_gauge("inode_dir_num", "Total dir")?,
@@ -235,7 +232,6 @@ impl MasterMetrics {
             .set(filesystem_info.allocatable_capacity);
         self.allocatable_available
             .set(filesystem_info.allocatable_available);
-        self.used_memory_bytes.set(SysUtils::used_memory() as i64);
 
         if filesystem_info.block_num > 0 {
             let avg_size = filesystem_info.fs_used / filesystem_info.block_num;

--- a/curvine-worker/src/worker/worker_metrics.rs
+++ b/curvine-worker/src/worker/worker_metrics.rs
@@ -16,7 +16,6 @@ use crate::worker::block::BlockStore;
 use crate::worker::storage::Dataset;
 use curvine_core_error::CommonResult;
 use curvine_metrics::{Counter, CounterVec, Gauge, GaugeVec, HistogramVec, Metrics, Metrics as m};
-use curvine_sys::SysUtils;
 use std::fmt::{Debug, Formatter};
 
 pub struct WorkerMetrics {
@@ -49,8 +48,6 @@ pub struct WorkerMetrics {
     pub(crate) disk_free_ratio: GaugeVec,
     /// Writes rejected because storage admission reported insufficient capacity.
     pub(crate) disk_full_rejected_writes: Counter,
-
-    pub(crate) used_memory_bytes: Gauge,
 }
 
 impl WorkerMetrics {
@@ -109,8 +106,6 @@ impl WorkerMetrics {
                 "disk_full_rejected_writes",
                 "Writes rejected because the storage layer reported insufficient capacity",
             )?,
-
-            used_memory_bytes: m::new_gauge("used_memory_bytes", "Total memory used")?,
         };
 
         Ok(wm)
@@ -127,7 +122,6 @@ impl WorkerMetrics {
             .set(state.num_blocks_to_delete() as i64);
 
         self.storage_failed.set(state.failed_storage_count() as i64);
-        self.used_memory_bytes.set(SysUtils::used_memory() as i64);
 
         self.store_total_disks.set(state.storage_count() as i64);
 


### PR DESCRIPTION
# Summary

Remove three redundant process-memory metrics: `WorkerMetrics.used_memory_bytes`, `MasterMetrics.used_memory_bytes` and `FuseMetrics.fuse_used_memory_bytes`. The worker/master gauges merely report whole-process memory via `SysUtils::used_memory()`, duplicating generic process-level information on per-component metrics endpoints; the FUSE gauge is registered but never set anywhere.

# Issue Describe / Design

Closes #1656

Design decisions:
- Delete the fields, registrations and `SysUtils::used_memory()` updates in `text_output`, plus the now-unused `SysUtils` imports.
- Keep the public `SysUtils::used_memory()` helper in `curvine-sys` unchanged.
- Write-back cache memory usage remains covered by dedicated metrics (`write_back_mem_usage`, `write_back_mem_limit`).

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-worker/src/worker/worker_metrics.rs` | Remove `used_memory_bytes` gauge (field, registration, update; drop unused `SysUtils` import) | None; metric no longer exported |
| `curvine-master/src/master/master_metrics.rs` | Remove `used_memory_bytes` gauge (field, registration, update; drop unused `SysUtils` import) | None; metric no longer exported |
| `curvine-fuse/src/fuse_metrics.rs` | Remove never-set `fuse_used_memory_bytes` gauge (field and registration) | None; metric no longer exported |

# Dependencies

- Related PRs: None
- Related issues: #1656
- Blocks / blocked by: None
