### PR TITLE
feat(mds): make FoundationDB backend optional via fdb feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,7 @@ curvine-ufs-opendal = { path = "crates/adapters/curvine-ufs-opendal" }
 curvine-ufs-oss-hdfs = { path = "crates/adapters/curvine-ufs-oss-hdfs" }
 curvine-hdfs-jni = { path = "crates/adapters/curvine-hdfs-jni" }
 curvine-data-transfer = { path = "crates/server/curvine-data-transfer" }
-curvine-mds = { path = "curvine-mds" }
+curvine-mds = { path = "curvine-mds", default-features = false }
 curvine-fault = { path = "crates/core/curvine-fault" }
 curvine-metrics = { path = "crates/core/curvine-metrics" }
 curvine-error = { path = "crates/common/curvine-error" }
@@ -147,7 +147,7 @@ curvine-client = { path = "curvine-client", default-features = false }
 curvine-libsdk = { path = "curvine-libsdk" }
 curvine-libsdk-java = { path = "crates/sdk/curvine-libsdk-java" }
 curvine-libsdk-python = { path = "crates/sdk/curvine-libsdk-python" }
-curvine-server = { path = "curvine-server" }
+curvine-server = { path = "curvine-server", default-features = false }
 curvine-lancedb = { path = "curvine-lancedb" }
 curvine-ufs = { path = "curvine-ufs" }
 # Test harness dependency entry is for explicit test/dev tooling only.

--- a/build/build.sh
+++ b/build/build.sh
@@ -136,7 +136,7 @@ print_help() {
   echo "  --spdk                Enable SPDK NVMe-oF initiator support for the server-native build (TCP transport)"
   echo "  --spdk-rdma           Enable SPDK NVMe-oF initiator support for the server-native build (TCP + RDMA transport)"
   echo "  --spdk-dir PATH       Path to pre-built SPDK installation (default: /opt/spdk or \$SPDK_DIR)"
-  echo "  --no-fdb              Disable the FoundationDB KV backend (no libfdb_c link-time dependency; MDS rejects kv_backend=fdb)"
+  echo "  --fdb                 Enable the FoundationDB KV backend (links libfdb_c; requires the FoundationDB client library)"
   echo "  --skip-java-sdk        Skip Java SDK compilation (useful for Docker builds)"
   echo "  --skip-python-sdk      Skip Python SDK compilation (useful for Docker builds)"
   echo "  -h, --help            Show this help message"
@@ -156,7 +156,7 @@ print_help() {
   echo "                                          # Build server-native SPDK/RDMA separately from client/CLI artifacts"
   echo "  $0 --skip-java-sdk                      # Build all packages except Java SDK"
   echo "  $0 --skip-python-sdk                    # Build all packages except Python SDK"
-  echo "  $0 -p server --no-fdb                   # Build server without the FoundationDB backend"
+  echo "  $0 -p server --fdb                      # Build server with the FoundationDB KV backend"
   echo "  $0 -p java -p python                    # Build both Java and Python SDKs"
 }
 
@@ -188,7 +188,7 @@ SKIP_JAVA_SDK=0    # Flag to skip Java SDK compilation
 SKIP_PYTHON_SDK=0  # Flag to skip Python SDK compilation
 ENABLE_SPDK=0      # Flag to enable SPDK TCP initiator support
 ENABLE_SPDK_RDMA=0 # Flag to enable SPDK RDMA initiator support
-ENABLE_FDB=1       # Flag to enable the FoundationDB KV backend (default on)
+ENABLE_FDB=0       # Flag to enable the FoundationDB KV backend (default off)
 SPDK_DIR="${SPDK_DIR:-}"  # Path to pre-built SPDK installation
 
 # Parse command line arguments. Avoid external getopt: BSD getopt silently
@@ -288,8 +288,8 @@ while [ $# -gt 0 ]; do
       SPDK_DIR="${1#*=}"
       shift
       ;;
-    --no-fdb)
-      ENABLE_FDB=0
+    --fdb)
+      ENABLE_FDB=1
       shift
       ;;
     --skip-java-sdk)

--- a/build/build.sh
+++ b/build/build.sh
@@ -136,6 +136,7 @@ print_help() {
   echo "  --spdk                Enable SPDK NVMe-oF initiator support for the server-native build (TCP transport)"
   echo "  --spdk-rdma           Enable SPDK NVMe-oF initiator support for the server-native build (TCP + RDMA transport)"
   echo "  --spdk-dir PATH       Path to pre-built SPDK installation (default: /opt/spdk or \$SPDK_DIR)"
+  echo "  --no-fdb              Disable the FoundationDB KV backend (no libfdb_c link-time dependency; MDS rejects kv_backend=fdb)"
   echo "  --skip-java-sdk        Skip Java SDK compilation (useful for Docker builds)"
   echo "  --skip-python-sdk      Skip Python SDK compilation (useful for Docker builds)"
   echo "  -h, --help            Show this help message"
@@ -155,6 +156,7 @@ print_help() {
   echo "                                          # Build server-native SPDK/RDMA separately from client/CLI artifacts"
   echo "  $0 --skip-java-sdk                      # Build all packages except Java SDK"
   echo "  $0 --skip-python-sdk                    # Build all packages except Python SDK"
+  echo "  $0 -p server --no-fdb                   # Build server without the FoundationDB backend"
   echo "  $0 -p java -p python                    # Build both Java and Python SDKs"
 }
 
@@ -186,6 +188,7 @@ SKIP_JAVA_SDK=0    # Flag to skip Java SDK compilation
 SKIP_PYTHON_SDK=0  # Flag to skip Python SDK compilation
 ENABLE_SPDK=0      # Flag to enable SPDK TCP initiator support
 ENABLE_SPDK_RDMA=0 # Flag to enable SPDK RDMA initiator support
+ENABLE_FDB=1       # Flag to enable the FoundationDB KV backend (default on)
 SPDK_DIR="${SPDK_DIR:-}"  # Path to pre-built SPDK installation
 
 # Parse command line arguments. Avoid external getopt: BSD getopt silently
@@ -283,6 +286,10 @@ while [ $# -gt 0 ]; do
     --spdk-dir=*)
       require_option_value "--spdk-dir" "${1#*=}"
       SPDK_DIR="${1#*=}"
+      shift
+      ;;
+    --no-fdb)
+      ENABLE_FDB=0
       shift
       ;;
     --skip-java-sdk)
@@ -793,6 +800,9 @@ FEATURES=()
 append_ufs_features "server-native"
 append_extra_features "server-native"
 append_alloc_feature "server-native"
+if [ $ENABLE_FDB -eq 1 ]; then
+  add_feature "curvine-server/fdb"
+fi
 if [ $ENABLE_SPDK -eq 1 ]; then
   add_feature "curvine-server/spdk"
   echo "Enabling SPDK NVMe-oF initiator support (TCP transport)"
@@ -824,6 +834,9 @@ FEATURES=()
 append_ufs_features "tests"
 append_extra_features "tests"
 append_alloc_feature "tests"
+if [ $ENABLE_FDB -eq 1 ]; then
+  add_feature "curvine-server/fdb"
+fi
 if [ $ENABLE_SPDK -eq 1 ]; then
   add_feature "curvine-server/spdk"
 fi

--- a/curvine-mds/Cargo.toml
+++ b/curvine-mds/Cargo.toml
@@ -5,10 +5,11 @@ edition.workspace = true
 license.workspace = true
 
 [features]
-# FoundationDB KV backend. Enabled by default; disable (--no-default-features
-# or via the parent crate) to drop the libfdb_c link-time dependency and the
-# bindgen build-time dependency entirely.
-default = ["fdb"]
+# FoundationDB KV backend. Off by default (like the SPDK features): it pulls
+# in the libfdb_c link-time dependency and the bindgen build-time dependency.
+# Enable explicitly with `--features fdb` / `--fdb` when the MDS must run
+# against a real FoundationDB cluster.
+default = []
 fdb = ["dep:foundationdb"]
 
 [dependencies]

--- a/curvine-mds/Cargo.toml
+++ b/curvine-mds/Cargo.toml
@@ -4,6 +4,13 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[features]
+# FoundationDB KV backend. Enabled by default; disable (--no-default-features
+# or via the parent crate) to drop the libfdb_c link-time dependency and the
+# bindgen build-time dependency entirely.
+default = ["fdb"]
+fdb = ["dep:foundationdb"]
+
 [dependencies]
 curvine-config = { workspace = true }
 curvine-core-error = { workspace = true }
@@ -11,7 +18,7 @@ curvine-metrics = { workspace = true }
 curvine-runtime = { workspace = true }
 async-trait = { workspace = true }
 fastrand = { workspace = true }
-foundationdb = { workspace = true, features = ["fdb-7_3", "embedded-fdb-include"] }
+foundationdb = { workspace = true, optional = true, features = ["fdb-7_3", "embedded-fdb-include"] }
 log = { workspace = true }
 once_cell = { workspace = true }
 thiserror = { workspace = true }

--- a/curvine-mds/src/kv/contract_tests.rs
+++ b/curvine-mds/src/kv/contract_tests.rs
@@ -500,7 +500,8 @@ async fn memory_apply_then_unknown_does_not_flip_successful_cas() {
 
 // ===== fdb backend bindings =====
 //
-// Gated behind the `fdb` cargo feature (off with --no-fdb) and the
+// Gated behind the `fdb` cargo feature (off by default; enable with
+// --features fdb) and the
 // `CURVINE_MDS_FDB_CLUSTER` env var. Point it at a cluster
 // file (the same one `fdbcli -C <file>` accepts). Runs the identical contract
 // suite against real FoundationDB, e.g.:

--- a/curvine-mds/src/kv/contract_tests.rs
+++ b/curvine-mds/src/kv/contract_tests.rs
@@ -507,7 +507,7 @@ async fn memory_apply_then_unknown_does_not_flip_successful_cas() {
 // suite against real FoundationDB, e.g.:
 //
 //   CURVINE_MDS_FDB_CLUSTER=/path/to/fdb.cluster \
-//     cargo test -p curvine-mds fdb_backend_satisfies_contract
+//     cargo test -p curvine-mds --features fdb fdb_backend_satisfies_contract
 //
 // A unique per-run key prefix isolates this run's keyspace on the shared
 // cluster, so leftover keys from earlier runs never fail a fresh assertion.

--- a/curvine-mds/src/kv/contract_tests.rs
+++ b/curvine-mds/src/kv/contract_tests.rs
@@ -500,7 +500,8 @@ async fn memory_apply_then_unknown_does_not_flip_successful_cas() {
 
 // ===== fdb backend bindings =====
 //
-// Gated behind the `CURVINE_MDS_FDB_CLUSTER` env var. Point it at a cluster
+// Gated behind the `fdb` cargo feature (off with --no-fdb) and the
+// `CURVINE_MDS_FDB_CLUSTER` env var. Point it at a cluster
 // file (the same one `fdbcli -C <file>` accepts). Runs the identical contract
 // suite against real FoundationDB, e.g.:
 //
@@ -509,6 +510,7 @@ async fn memory_apply_then_unknown_does_not_flip_successful_cas() {
 //
 // A unique per-run key prefix isolates this run's keyspace on the shared
 // cluster, so leftover keys from earlier runs never fail a fresh assertion.
+#[cfg(feature = "fdb")]
 #[tokio::test]
 async fn fdb_backend_satisfies_contract() {
     use crate::kv::fdb::FdbBackend;
@@ -546,6 +548,7 @@ async fn fdb_backend_satisfies_contract() {
 //
 // Needs no real cluster (it boots the FDB network and targets a dead address),
 // so it runs wherever libfdb_c links; it is not gated on CURVINE_MDS_FDB_CLUSTER.
+#[cfg(feature = "fdb")]
 #[tokio::test]
 async fn fdb_unreachable_cluster_does_not_hang() {
     use crate::kv::fdb::FdbBackend;

--- a/curvine-mds/src/kv/metrics.rs
+++ b/curvine-mds/src/kv/metrics.rs
@@ -36,6 +36,7 @@ const LATENCY_BUCKETS_US: &[f64] = &[
 
 /// KV size buckets in bytes. Centred on the ~128B target single-KV budget so the
 /// P50/P95/P99 around it are visible, with headroom for oversized records.
+#[cfg(feature = "fdb")]
 const KV_SIZE_BUCKETS_BYTES: &[f64] = &[
     16.0, 32.0, 64.0, 128.0, 256.0, 512.0, 1_024.0, 2_048.0, 4_096.0, 16_384.0, 65_536.0,
 ];
@@ -57,8 +58,10 @@ pub struct KvMetrics {
     /// Currently in-flight transactions.
     pub txn_in_flight: Gauge,
     /// Distribution of key sizes written to the backend, in bytes, by backend.
+    #[cfg(feature = "fdb")]
     pub kv_key_size_bytes: HistogramVec,
     /// Distribution of value sizes written to the backend, in bytes, by backend.
+    #[cfg(feature = "fdb")]
     pub kv_value_size_bytes: HistogramVec,
 }
 
@@ -100,12 +103,14 @@ impl KvMetrics {
                 "mds_kv_txn_in_flight",
                 "Currently in-flight KV transactions",
             )?,
+            #[cfg(feature = "fdb")]
             kv_key_size_bytes: Metrics::new_histogram_vec_with_buckets(
                 "mds_kv_key_size_bytes",
                 "Distribution of KV key sizes in bytes",
                 &["backend"],
                 KV_SIZE_BUCKETS_BYTES,
             )?,
+            #[cfg(feature = "fdb")]
             kv_value_size_bytes: Metrics::new_histogram_vec_with_buckets(
                 "mds_kv_value_size_bytes",
                 "Distribution of KV value sizes in bytes",
@@ -141,6 +146,7 @@ impl KvMetrics {
 
     /// Records the byte size of a key/value pair buffered for write, so the
     /// KV-size distribution (P50/P95/P99 vs the ~128B budget) is observable.
+    #[cfg(feature = "fdb")]
     pub fn observe_kv_size(&self, backend: &str, key_len: usize, value_len: usize) {
         self.kv_key_size_bytes
             .with_label_values(&[backend])

--- a/curvine-mds/src/kv/mod.rs
+++ b/curvine-mds/src/kv/mod.rs
@@ -9,12 +9,14 @@
 
 mod backend;
 mod error;
+#[cfg(feature = "fdb")]
 mod fdb;
 mod memory;
 pub mod metrics;
 
 pub use backend::{run_txn, KvBackend, KvTransaction, DEFAULT_MAX_RETRIES};
 pub use error::{KvError, KvResult};
+#[cfg(feature = "fdb")]
 pub use fdb::FdbBackend;
 pub use memory::{FaultInjector, MemoryBackend};
 

--- a/curvine-mds/src/lib.rs
+++ b/curvine-mds/src/lib.rs
@@ -1,6 +1,7 @@
 mod kv;
 mod server;
 
+#[cfg(feature = "fdb")]
 pub use kv::FdbBackend;
 pub use kv::{
     run_txn, FaultInjector, KvBackend, KvError, KvResult, KvTransaction, MemoryBackend,

--- a/curvine-mds/src/server.rs
+++ b/curvine-mds/src/server.rs
@@ -6,8 +6,9 @@ use log::info;
 use std::sync::Arc;
 use tokio::sync::watch;
 
-use crate::{FdbBackend, KvBackend, MemoryBackend};
-
+#[cfg(feature = "fdb")]
+use crate::FdbBackend;
+use crate::{KvBackend, MemoryBackend};
 pub struct Mds {
     conf: ClusterConf,
     backend: Arc<dyn KvBackend>,
@@ -26,10 +27,18 @@ impl Mds {
 
         let backend: Arc<dyn KvBackend> = match conf.mds.kv_backend {
             KvBackendType::Memory => Arc::new(MemoryBackend::new()),
+            #[cfg(feature = "fdb")]
             KvBackendType::Fdb => Arc::new(
                 FdbBackend::open(&conf.mds.fdb_cluster_file, conf.mds.fdb_txn_timeout_ms)
                     .map_err(|error| curvine_core_error::CommonError::from(error.to_string()))?,
             ),
+            #[cfg(not(feature = "fdb"))]
+            KvBackendType::Fdb => {
+                return err_box!(
+                    "mds.kv_backend=fdb requires the \"fdb\" feature \
+                     (build with --features fdb or without --no-fdb)"
+                );
+            }
         };
         let rt = Arc::new(AsyncRuntime::new(
             "mds",

--- a/curvine-mds/src/server.rs
+++ b/curvine-mds/src/server.rs
@@ -36,7 +36,7 @@ impl Mds {
             KvBackendType::Fdb => {
                 return err_box!(
                     "mds.kv_backend=fdb requires the \"fdb\" feature \
-                     (build with --features fdb or without --no-fdb)"
+                     (build with --features fdb)"
                 );
             }
         };

--- a/curvine-mds/src/server.rs
+++ b/curvine-mds/src/server.rs
@@ -22,6 +22,17 @@ impl Mds {
         if !conf.mds.enabled {
             return err_box!("mds service is disabled; set mds.enabled=true to start it");
         }
+        // Reject kv_backend=fdb before config init() so users get the
+        // actionable "rebuild with fdb" message even when other config fields
+        // (e.g. an empty fdb_cluster_file) would otherwise fail validation
+        // first with a less helpful error.
+        #[cfg(not(feature = "fdb"))]
+        if conf.mds.kv_backend == KvBackendType::Fdb {
+            return err_box!(
+                "mds.kv_backend=fdb requires the \"fdb\" feature \
+                 (build with --features fdb)"
+            );
+        }
         conf.mds.init()?;
         Logger::init(conf.mds.log.clone());
 
@@ -178,11 +189,10 @@ mod tests {
     #[cfg(not(feature = "fdb"))]
     #[test]
     fn rejects_fdb_backend_when_feature_disabled() {
+        // Default config: kv_backend=Fdb with non-empty fdb_cluster_file.
+        // The feature-required error should fire before init() validation.
         let mut conf = ClusterConf::default();
         conf.mds.enabled = true;
-        // KvBackendType::Fdb is the default; fdb_cluster_file is non-empty in
-        // the default so init() passes. The cfg(not(feature = "fdb")) arm in
-        // Mds::with_conf should then produce the feature-required error.
         let err = match Mds::with_conf(conf) {
             Ok(_) => panic!("expected fdb feature error when fdb feature is disabled"),
             Err(e) => e,
@@ -191,6 +201,21 @@ mod tests {
         assert!(
             msg.contains("\"fdb\" feature"),
             "expected error mentioning the 'fdb' feature, got: {msg}"
+        );
+
+        // Empty fdb_cluster_file: init() would normally reject it, but the
+        // early feature check should fire first with the same actionable error.
+        let mut conf2 = ClusterConf::default();
+        conf2.mds.enabled = true;
+        conf2.mds.fdb_cluster_file.clear();
+        let err2 = match Mds::with_conf(conf2) {
+            Ok(_) => panic!("expected fdb feature error even with empty cluster file"),
+            Err(e) => e,
+        };
+        let msg2 = format!("{err2}");
+        assert!(
+            msg2.contains("\"fdb\" feature"),
+            "expected error mentioning the 'fdb' feature with empty cluster file, got: {msg2}"
         );
     }
 }

--- a/curvine-mds/src/server.rs
+++ b/curvine-mds/src/server.rs
@@ -174,4 +174,23 @@ mod tests {
         let mds = Mds::with_conf(conf).unwrap();
         assert_eq!(mds.backend().name(), "memory");
     }
+
+    #[cfg(not(feature = "fdb"))]
+    #[test]
+    fn rejects_fdb_backend_when_feature_disabled() {
+        let mut conf = ClusterConf::default();
+        conf.mds.enabled = true;
+        // KvBackendType::Fdb is the default; fdb_cluster_file is non-empty in
+        // the default so init() passes. The cfg(not(feature = "fdb")) arm in
+        // Mds::with_conf should then produce the feature-required error.
+        let err = match Mds::with_conf(conf) {
+            Ok(_) => panic!("expected fdb feature error when fdb feature is disabled"),
+            Err(e) => e,
+        };
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("\"fdb\" feature"),
+            "expected error mentioning the 'fdb' feature, got: {msg}"
+        );
+    }
 }

--- a/curvine-server/Cargo.toml
+++ b/curvine-server/Cargo.toml
@@ -7,7 +7,11 @@ license.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = []
+# fdb is on by default to preserve today's behavior (FoundationDB KV backend).
+# Disable with --no-default-features/--no-fdb to drop the libfdb_c link-time
+# dependency; the MDS then rejects `kv_backend = "fdb"` at startup.
+default = ["fdb"]
+fdb = ["curvine-mds/fdb"]
 jni = ["curvine-data-transfer/opendal-hdfs"]
 spdk = [
     "curvine-worker/spdk",
@@ -38,7 +42,7 @@ curvine-alloc = { workspace = true }
 curvine-model = { workspace = true }
 curvine-runtime = { workspace = true }
 curvine-master = { workspace = true }
-curvine-mds = { workspace = true }
+curvine-mds = { workspace = true, default-features = false }
 curvine-worker = { workspace = true }
 curvine-error = { workspace = true, features = ["axum-response"] }
 curvine-fault = { workspace = true }

--- a/curvine-server/Cargo.toml
+++ b/curvine-server/Cargo.toml
@@ -7,10 +7,10 @@ license.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-# fdb is on by default to preserve today's behavior (FoundationDB KV backend).
-# Disable with --no-default-features/--no-fdb to drop the libfdb_c link-time
-# dependency; the MDS then rejects `kv_backend = "fdb"` at startup.
-default = ["fdb"]
+# fdb is off by default (like the SPDK features). Enable it with
+# --features fdb / --fdb to build the FoundationDB KV backend; the MDS then
+# rejects `kv_backend = "fdb"` at startup when compiled without it.
+default = []
 fdb = ["curvine-mds/fdb"]
 jni = ["curvine-data-transfer/opendal-hdfs"]
 spdk = [

--- a/curvine-tests/Cargo.toml
+++ b/curvine-tests/Cargo.toml
@@ -12,6 +12,11 @@ publish = false
 # Enable OSS-HDFS backend specific tests / code paths (Jindo-based).
 # This is used by `#[cfg(feature = "oss-hdfs")]` in integration tests.
 oss-hdfs = ["curvine-client/oss-hdfs"]
+# FoundationDB backend (via curvine-server). On by default to preserve today's
+# behavior; disable with --no-fdb / --no-default-features to build the test
+# harness without the libfdb_c link-time dependency.
+default = ["fdb"]
+fdb = ["curvine-server/fdb"]
 lancedb = [
     "dep:curvine-lancedb",
     "dep:lance-io",
@@ -38,7 +43,7 @@ curvine-error = { workspace = true }
 curvine-config = { workspace = true }
 curvine-sys = { workspace = true }
 curvine-alloc = { workspace = true }
-curvine-server = { workspace = true }
+curvine-server = { workspace = true, default-features = false }
 curvine-client = { workspace = true, features = ["job-client", "unified", "opendal-s3"] }
 curvine-lancedb = { workspace = true, optional = true }
 curvine-ufs-api = { workspace = true }

--- a/curvine-tests/Cargo.toml
+++ b/curvine-tests/Cargo.toml
@@ -12,10 +12,10 @@ publish = false
 # Enable OSS-HDFS backend specific tests / code paths (Jindo-based).
 # This is used by `#[cfg(feature = "oss-hdfs")]` in integration tests.
 oss-hdfs = ["curvine-client/oss-hdfs"]
-# FoundationDB backend (via curvine-server). On by default to preserve today's
-# behavior; disable with --no-fdb / --no-default-features to build the test
-# harness without the libfdb_c link-time dependency.
-default = ["fdb"]
+# FoundationDB backend (via curvine-server). Off by default; enable with
+# --fdb / --features fdb to build the test harness with the libfdb_c
+# link-time dependency.
+default = []
 fdb = ["curvine-server/fdb"]
 lancedb = [
     "dep:curvine-lancedb",


### PR DESCRIPTION
## Problem
curvine-mds hard-links the FoundationDB client (libfdb_c) and pulls in
bindgen at build time, so any build that includes the server requires
libfdb_c on the link line and LLVM/libclang at compile time. Users
deploying with the memory KV backend still pay the FoundationDB
dependency cost.

## Design
Add an `fdb` cargo feature to curvine-mds, making the foundationdb
crate optional. The feature is **opt-in** (off by default, like the
SPDK features): all FDB-only code (backend, exports, metrics, contract
tests) is gated with `#[cfg(feature = "fdb")]`. curvine-server and
curvine-tests forward the feature. build.sh gains a `--fdb` flag that
adds `curvine-server/fdb` to the build feature set; the MDS rejects
`kv_backend = "fdb"` at startup with a clear error when compiled
without it.

## Key Changes
- curvine-mds: foundationdb dep optional, empty default features, fdb code gated
- curvine-mds/src/server.rs: reject kv_backend=fdb when compiled without fdb
- curvine-mds/src/kv/metrics.rs: gate fdb-only kv-size metrics
- curvine-mds/src/kv/contract_tests.rs: gate FDB contract tests
- curvine-server / curvine-tests: forward fdb feature, default off
- build/build.sh: add `--fdb` flag (server/tests include curvine-server/fdb)
- Default: no fdb, no libfdb_c link-time dependency