### PR TITLE
fix(java): harden SDK runtime packaging

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -9,6 +9,11 @@
 # args: `-Wl,-Bstatic` `-lstdc++` `-Wl,-Bdynamic`.
 linker = "build/static-link-wrapper.sh"
 
+[target.aarch64-unknown-linux-gnu]
+# Same wrapper is required on Linux ARM; otherwise the JNI so can keep dynamic
+# DT_NEEDED entries for libstdc++, libgcc_s, and zlib.
+linker = "build/static-link-wrapper.sh"
+
 [target.x86_64-apple-darwin]
 rustflags = [
     "-C", "link-arg=-undefined",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2112,7 +2112,7 @@ dependencies = [
 
 [[package]]
 name = "curvine-alloc"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "mimalloc",
  "tikv-jemallocator",
@@ -2120,7 +2120,7 @@ dependencies = [
 
 [[package]]
 name = "curvine-bench"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "curvine-core-error",
  "curvine-fs-api",
@@ -2133,7 +2133,7 @@ dependencies = [
 
 [[package]]
 name = "curvine-cli"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "bytes",
  "chrono",
@@ -2163,7 +2163,7 @@ dependencies = [
 
 [[package]]
 name = "curvine-client"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "clap",
  "curvine-bench",
@@ -2175,7 +2175,7 @@ dependencies = [
 
 [[package]]
 name = "curvine-client-core"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "async-stream",
  "bytes",
@@ -2212,7 +2212,7 @@ dependencies = [
 
 [[package]]
 name = "curvine-common-macros"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "clap",
  "curvine-core-error",
@@ -2224,7 +2224,7 @@ dependencies = [
 
 [[package]]
 name = "curvine-config"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "clap",
  "curvine-common-macros",
@@ -2247,7 +2247,7 @@ dependencies = [
 
 [[package]]
 name = "curvine-core-error"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "bincode",
  "bytes",
@@ -2257,7 +2257,7 @@ dependencies = [
 
 [[package]]
 name = "curvine-data-transfer"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "axum 0.7.9",
  "bytes",
@@ -2303,7 +2303,7 @@ dependencies = [
 
 [[package]]
 name = "curvine-error"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "axum 0.7.9",
  "curvine-core-error",
@@ -2317,7 +2317,7 @@ dependencies = [
 
 [[package]]
 name = "curvine-fault"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "async-trait",
  "axum 0.7.9",
@@ -2332,7 +2332,7 @@ dependencies = [
 
 [[package]]
 name = "curvine-fs-api"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "async-stream",
  "bytes",
@@ -2354,7 +2354,7 @@ dependencies = [
 
 [[package]]
 name = "curvine-fuse"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "axum 0.7.9",
  "bitflags 2.10.0",
@@ -2398,7 +2398,7 @@ dependencies = [
 
 [[package]]
 name = "curvine-hdfs-jni"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "jni",
@@ -2407,7 +2407,7 @@ dependencies = [
 
 [[package]]
 name = "curvine-io"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "bytes",
  "curvine-core-error",
@@ -2421,7 +2421,7 @@ dependencies = [
 
 [[package]]
 name = "curvine-job-client"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "bincode",
  "curvine-client-core",
@@ -2442,7 +2442,7 @@ dependencies = [
 
 [[package]]
 name = "curvine-lancedb"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -2477,16 +2477,17 @@ dependencies = [
 
 [[package]]
 name = "curvine-libsdk"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "curvine-libsdk-java",
  "curvine-libsdk-python",
  "curvine-sdk-core",
+ "libc",
 ]
 
 [[package]]
 name = "curvine-libsdk-java"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "curvine-core-error",
  "curvine-error",
@@ -2499,7 +2500,7 @@ dependencies = [
 
 [[package]]
 name = "curvine-libsdk-python"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "bytes",
  "curvine-config",
@@ -2512,7 +2513,7 @@ dependencies = [
 
 [[package]]
 name = "curvine-master"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "axum 0.7.9",
  "bytes",
@@ -2556,7 +2557,7 @@ dependencies = [
 
 [[package]]
 name = "curvine-mds"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "async-trait",
  "curvine-config",
@@ -2573,7 +2574,7 @@ dependencies = [
 
 [[package]]
 name = "curvine-metrics"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "curvine-core-error",
  "dashmap 5.5.3",
@@ -2584,7 +2585,7 @@ dependencies = [
 
 [[package]]
 name = "curvine-model"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "bincode",
  "bitflags 2.10.0",
@@ -2606,7 +2607,7 @@ dependencies = [
 
 [[package]]
 name = "curvine-net"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "curvine-core-error",
  "curvine-io",
@@ -2618,7 +2619,7 @@ dependencies = [
 
 [[package]]
 name = "curvine-proto"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "prost 0.11.9",
  "prost-build 0.11.9",
@@ -2627,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "curvine-raft"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "bincode",
  "bytes",
@@ -2657,7 +2658,7 @@ dependencies = [
 
 [[package]]
 name = "curvine-rocksdb"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "byteorder",
  "curvine-config",
@@ -2672,7 +2673,7 @@ dependencies = [
 
 [[package]]
 name = "curvine-rpc"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "bytes",
  "curvine-core-error",
@@ -2691,7 +2692,7 @@ dependencies = [
 
 [[package]]
 name = "curvine-runtime"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "bincode",
  "chrono",
@@ -2723,7 +2724,7 @@ dependencies = [
 
 [[package]]
 name = "curvine-sdk-core"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "bytes",
  "curvine-client",
@@ -2745,7 +2746,7 @@ dependencies = [
 
 [[package]]
 name = "curvine-server"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "axum 0.7.9",
  "bytes",
@@ -2793,7 +2794,7 @@ dependencies = [
 
 [[package]]
 name = "curvine-service-discovery"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "async-trait",
  "curvine-config",
@@ -2810,14 +2811,14 @@ dependencies = [
 
 [[package]]
 name = "curvine-storage-api"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "curvine-model",
 ]
 
 [[package]]
 name = "curvine-storage-local"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "byteorder",
  "bytes",
@@ -2836,7 +2837,7 @@ dependencies = [
 
 [[package]]
 name = "curvine-storage-spdk"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "bytes",
  "cc",
@@ -2855,7 +2856,7 @@ dependencies = [
 
 [[package]]
 name = "curvine-sys"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "bytes",
  "curvine-runtime",
@@ -2910,14 +2911,14 @@ dependencies = [
 
 [[package]]
 name = "curvine-ufs"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "curvine-ufs-api",
 ]
 
 [[package]]
 name = "curvine-ufs-api"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2935,7 +2936,7 @@ dependencies = [
 
 [[package]]
 name = "curvine-ufs-opendal"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "bytes",
  "curvine-core-error",
@@ -2953,7 +2954,7 @@ dependencies = [
 
 [[package]]
 name = "curvine-ufs-oss-hdfs"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2974,7 +2975,7 @@ dependencies = [
 
 [[package]]
 name = "curvine-unified-fs"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "bytes",
  "curvine-client-core",
@@ -2996,7 +2997,7 @@ dependencies = [
 
 [[package]]
 name = "curvine-web"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "axum 0.7.9",
  "curvine-core-error",
@@ -3015,7 +3016,7 @@ dependencies = [
 
 [[package]]
 name = "curvine-worker"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "axum 0.7.9",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.2"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/build/static-link-wrapper.sh
+++ b/build/static-link-wrapper.sh
@@ -12,6 +12,13 @@
 #   CURVINE_STATIC_LINK=1 cargo build --release
 #
 # Without the variable (default), arguments are passed through unchanged.
+#
+# Optional:
+#   CURVINE_JINDOSDK_LIB=/path/to/libjindosdk_c.so
+# Some CentOS 7 aarch64 final links can fail to resolve -ljindosdk_c after
+# mixed static/dynamic transitions. Passing the exact shared object keeps the
+# final binary's DT_NEEDED on libjindosdk_c.so.6 while avoiding linker search
+# ambiguity.
 
 set -euo pipefail
 
@@ -19,20 +26,77 @@ if [ "${CURVINE_STATIC_LINK:-0}" != "1" ]; then
     exec "${CC:-cc}" "$@"
 fi
 
+have_static_archive() {
+    local archive_name="$1"
+    local archive_path
+
+    if [ -n "${CURVINE_STATIC_LIB_GCC_DIR:-}" ] && [ -f "${CURVINE_STATIC_LIB_GCC_DIR}/${archive_name}" ]; then
+        return 0
+    fi
+
+    archive_path="$("${CC:-cc}" -print-file-name="${archive_name}" 2>/dev/null || true)"
+    if [ -z "${archive_path}" ] || [ "${archive_path}" = "${archive_name}" ]; then
+        return 1
+    fi
+
+    [ -f "${archive_path}" ]
+}
+
 NEWARGS=()
 for arg in "$@"; do
     if [ "$arg" = "-lstdc++" ]; then
-        NEWARGS+=("-Wl,-Bstatic" "-lstdc++" "-Wl,-Bdynamic")
+        if have_static_archive "libstdc++.a"; then
+            if [ -n "${CURVINE_STATIC_LIB_GCC_DIR:-}" ] && [ -f "${CURVINE_STATIC_LIB_GCC_DIR}/libstdc++.a" ]; then
+                NEWARGS+=("-Wl,-Bstatic" "${CURVINE_STATIC_LIB_GCC_DIR}/libstdc++.a" "-Wl,-Bdynamic")
+            else
+                NEWARGS+=("-Wl,-Bstatic" "-lstdc++" "-Wl,-Bdynamic")
+            fi
+        else
+            NEWARGS+=("-lstdc++")
+        fi
     elif [ "$arg" = "-lgcc_s" ]; then
         # libgcc_s.so provides both the GCC runtime helpers and the EH
         # (exception-handling) unwinder. GCC does not ship a libgcc_s.a;
         # the static equivalents are libgcc.a (runtime) + libgcc_eh.a (EH).
-        NEWARGS+=("-Wl,-Bstatic" "-lgcc_eh" "-lgcc" "-Wl,-Bdynamic")
+        if have_static_archive "libgcc_eh.a" && have_static_archive "libgcc.a"; then
+            if [ -n "${CURVINE_STATIC_LIB_GCC_DIR:-}" ] \
+               && [ -f "${CURVINE_STATIC_LIB_GCC_DIR}/libgcc_eh.a" ] \
+               && [ -f "${CURVINE_STATIC_LIB_GCC_DIR}/libgcc.a" ]; then
+                NEWARGS+=(
+                    "-Wl,-Bstatic"
+                    "${CURVINE_STATIC_LIB_GCC_DIR}/libgcc_eh.a"
+                    "${CURVINE_STATIC_LIB_GCC_DIR}/libgcc.a"
+                    "-Wl,-Bdynamic"
+                )
+            else
+                NEWARGS+=("-Wl,-Bstatic" "-lgcc_eh" "-lgcc" "-Wl,-Bdynamic")
+            fi
+        else
+            NEWARGS+=("-lgcc_s")
+        fi
     elif [ "$arg" = "-lz" ]; then
-        NEWARGS+=("-Wl,-Bstatic" "-lz" "-Wl,-Bdynamic")
+        if have_static_archive "libz.a"; then
+            NEWARGS+=("-Wl,-Bstatic" "-lz" "-Wl,-Bdynamic")
+        else
+            NEWARGS+=("-lz")
+        fi
+    elif [ "$arg" = "-ljindosdk_c" ] && [ -n "${CURVINE_JINDOSDK_LIB:-}" ] && [ -f "${CURVINE_JINDOSDK_LIB}" ]; then
+        NEWARGS+=("${CURVINE_JINDOSDK_LIB}")
     else
         NEWARGS+=("$arg")
     fi
 done
+
+if [ -n "${CURVINE_LINK_WRAPPER_LOG:-}" ]; then
+    {
+        echo "==== $(date '+%Y-%m-%d %H:%M:%S') pid=$$ ===="
+        echo "-- original"
+        printf '%q ' "$@"
+        echo
+        echo "-- rewritten"
+        printf '%q ' "${NEWARGS[@]}"
+        echo
+    } >> "${CURVINE_LINK_WRAPPER_LOG}"
+fi
 
 exec "${CC:-cc}" "${NEWARGS[@]}"

--- a/crates/adapters/curvine-ufs-opendal/src/lib.rs
+++ b/crates/adapters/curvine-ufs-opendal/src/lib.rs
@@ -354,64 +354,8 @@ impl OpendalFileSystem {
                 Self::add_stability_layers(base_op, &conf)?
             }
 
-            #[cfg(feature = "opendal-hdfs")]
-            "hdfs" => {
-                use curvine_hdfs_jni::jni::{register_jvm, JVM};
-
-                register_jvm();
-
-                let _ = JVM.get_or_init().map_err(|e| {
-                    FsError::common(format!("Failed to initialize JVM for HDFS: {}", e))
-                })?;
-
-                let mut builder = Hdfs::default();
-
-                let namenode = if let Some(namenode_config) = conf.get("hdfs.namenode") {
-                    namenode_config.clone()
-                } else {
-                    format!("hdfs://{}", bucket_or_container)
-                };
-
-                builder = builder.name_node(&namenode);
-
-                let root_path = conf.get("hdfs.root").map(|s| s.as_str()).unwrap_or("/");
-                builder = builder.root(root_path);
-
-                let hdfs_user = conf
-                    .get("hdfs.user")
-                    .cloned()
-                    .or_else(|| std::env::var("HADOOP_USER_NAME").ok())
-                    .or_else(|| std::env::var("USER").ok());
-
-                if let Some(user) = hdfs_user {
-                    builder = builder.user(&user);
-                }
-
-                if let Some(ccache) = conf.get("hdfs.kerberos.ccache") {
-                    builder = builder.kerberos_ticket_cache_path(ccache);
-                } else if let Ok(ccache) = std::env::var("KRB5CCNAME") {
-                    builder = builder.kerberos_ticket_cache_path(&ccache);
-                }
-
-                if let Some(krb5_conf) = conf.get("hdfs.kerberos.krb5_conf") {
-                    std::env::set_var("KRB5_CONFIG", krb5_conf);
-                }
-
-                if conf
-                    .get("hdfs.atomic_write_dir")
-                    .map(|s| s == "true")
-                    .unwrap_or(false)
-                {
-                    let atomic_dir = format!("{}/atomic_write_dir", root_path);
-                    builder = builder.atomic_write_dir(&atomic_dir);
-                }
-
-                let base_op = Operator::new(builder)
-                    .map_err(|e| FsError::common(format!("Failed to create HDFS operator: {}", e)))?
-                    .finish();
-
-                Self::add_stability_layers(base_op, &conf)?
-            }
+            #[cfg(any(feature = "opendal-hdfs", feature = "opendal-hdfs-native"))]
+            "hdfs" => Self::create_hdfs_operator(&bucket_or_container, &conf)?,
 
             #[cfg(feature = "opendal-webhdfs")]
             "webhdfs" => {
@@ -553,9 +497,6 @@ impl OpendalFileSystem {
                 Self::add_stability_layers(base_op, &conf)?
             }
 
-            #[cfg(all(feature = "opendal-hdfs-native", not(feature = "opendal-hdfs")))]
-            "hdfs" => Self::create_hdfs_native_operator(&bucket_or_container, &conf)?,
-
             _ => {
                 return Err(FsError::unsupported(format!(
                     "Unsupported scheme: {}",
@@ -574,6 +515,119 @@ impl OpendalFileSystem {
             read_chunk_size: opendal_conf.read_chunk_size,
             read_concurrent: opendal_conf.read_concurrent,
         })
+    }
+
+    #[cfg(any(feature = "opendal-hdfs", feature = "opendal-hdfs-native"))]
+    fn create_hdfs_operator(
+        bucket_or_container: &str,
+        conf: &HashMap<String, String>,
+    ) -> FsResult<Operator> {
+        if Self::use_hdfs_native(conf) {
+            #[cfg(feature = "opendal-hdfs-native")]
+            {
+                return Self::create_hdfs_native_operator(bucket_or_container, conf);
+            }
+
+            #[cfg(not(feature = "opendal-hdfs-native"))]
+            {
+                return err_box!("opendal hdfs-native provider is not enabled");
+            }
+        }
+
+        #[cfg(feature = "opendal-hdfs")]
+        {
+            return Self::create_hdfs_jvm_operator(bucket_or_container, conf);
+        }
+
+        #[cfg(all(not(feature = "opendal-hdfs"), feature = "opendal-hdfs-native"))]
+        {
+            Self::create_hdfs_native_operator(bucket_or_container, conf)
+        }
+    }
+
+    #[cfg(any(feature = "opendal-hdfs", feature = "opendal-hdfs-native"))]
+    fn use_hdfs_native(conf: &HashMap<String, String>) -> bool {
+        let explicit_backend = conf
+            .get("hdfs.provider")
+            .or_else(|| conf.get("hdfs.backend"))
+            .or_else(|| conf.get("opendal.hdfs.driver"));
+
+        if let Some(value) = explicit_backend {
+            if value.eq_ignore_ascii_case("native") || value.eq_ignore_ascii_case("hdfs-native") {
+                return true;
+            }
+        }
+
+        conf.get("hdfs.native")
+            .map(|v| {
+                v.eq_ignore_ascii_case("true")
+                    || v.eq_ignore_ascii_case("1")
+                    || v.eq_ignore_ascii_case("yes")
+                    || v.eq_ignore_ascii_case("on")
+            })
+            .unwrap_or(false)
+    }
+
+    #[cfg(feature = "opendal-hdfs")]
+    fn create_hdfs_jvm_operator(
+        bucket_or_container: &str,
+        conf: &HashMap<String, String>,
+    ) -> FsResult<Operator> {
+        use curvine_hdfs_jni::jni::{register_jvm, JVM};
+
+        register_jvm();
+
+        let _ = JVM
+            .get_or_init()
+            .map_err(|e| FsError::common(format!("Failed to initialize JVM for HDFS: {}", e)))?;
+
+        let mut builder = Hdfs::default();
+
+        let namenode = if let Some(namenode_config) = conf.get("hdfs.namenode") {
+            namenode_config.clone()
+        } else {
+            format!("hdfs://{}", bucket_or_container)
+        };
+
+        builder = builder.name_node(&namenode);
+
+        let root_path = conf.get("hdfs.root").map(|s| s.as_str()).unwrap_or("/");
+        builder = builder.root(root_path);
+
+        let hdfs_user = conf
+            .get("hdfs.user")
+            .cloned()
+            .or_else(|| std::env::var("HADOOP_USER_NAME").ok())
+            .or_else(|| std::env::var("USER").ok());
+
+        if let Some(user) = hdfs_user {
+            builder = builder.user(&user);
+        }
+
+        if let Some(ccache) = conf.get("hdfs.kerberos.ccache") {
+            builder = builder.kerberos_ticket_cache_path(ccache);
+        } else if let Ok(ccache) = std::env::var("KRB5CCNAME") {
+            builder = builder.kerberos_ticket_cache_path(&ccache);
+        }
+
+        if let Some(krb5_conf) = conf.get("hdfs.kerberos.krb5_conf") {
+            std::env::set_var("KRB5_CONFIG", krb5_conf);
+        }
+
+        if conf
+            .get("hdfs.atomic_write_dir")
+            .map(|s| s == "true")
+            .unwrap_or(false)
+        {
+            let atomic_dir = format!("{}/atomic_write_dir", root_path);
+            builder = builder.atomic_write_dir(&atomic_dir);
+        }
+
+        let base_op = Operator::new(builder)
+            .map_err(|e| FsError::common(format!("Failed to create HDFS operator: {}", e)))?
+            .finish();
+
+        Self::add_stability_layers(base_op, conf)
     }
 
     /// Create HDFS Native operator (Rust native implementation, no JVM required)

--- a/crates/adapters/curvine-ufs-opendal/src/lib.rs
+++ b/crates/adapters/curvine-ufs-opendal/src/lib.rs
@@ -62,6 +62,7 @@ mod tests {
 
     #[test]
     fn hdfs_provider_selects_native_backend() {
+        assert!(!OpendalFileSystem::use_hdfs_native(&config(&[])));
         assert!(OpendalFileSystem::use_hdfs_native(&config(&[(
             "hdfs.provider",
             "native"
@@ -73,6 +74,10 @@ mod tests {
         assert!(!OpendalFileSystem::use_hdfs_native(&config(&[(
             "hdfs.provider",
             "jvm"
+        )])));
+        assert!(!OpendalFileSystem::use_hdfs_native(&config(&[(
+            "hdfs.provider",
+            "unknown"
         )])));
     }
 

--- a/crates/adapters/curvine-ufs-opendal/src/lib.rs
+++ b/crates/adapters/curvine-ufs-opendal/src/lib.rs
@@ -48,6 +48,51 @@ fn storage_error(
     }
 }
 
+#[cfg(all(test, any(feature = "opendal-hdfs", feature = "opendal-hdfs-native")))]
+mod tests {
+    use super::OpendalFileSystem;
+    use std::collections::HashMap;
+
+    fn config(entries: &[(&str, &str)]) -> HashMap<String, String> {
+        entries
+            .iter()
+            .map(|(key, value)| ((*key).to_string(), (*value).to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn hdfs_provider_selects_native_backend() {
+        assert!(OpendalFileSystem::use_hdfs_native(&config(&[(
+            "hdfs.provider",
+            "native"
+        )])));
+        assert!(OpendalFileSystem::use_hdfs_native(&config(&[(
+            "hdfs.provider",
+            "HDFS-NATIVE"
+        )])));
+        assert!(!OpendalFileSystem::use_hdfs_native(&config(&[(
+            "hdfs.provider",
+            "jvm"
+        )])));
+    }
+
+    #[test]
+    fn legacy_hdfs_native_flag_is_used_only_without_provider() {
+        assert!(OpendalFileSystem::use_hdfs_native(&config(&[(
+            "hdfs.native",
+            "true"
+        )])));
+        assert!(!OpendalFileSystem::use_hdfs_native(&config(&[(
+            "hdfs.native",
+            "false"
+        )])));
+        assert!(!OpendalFileSystem::use_hdfs_native(&config(&[
+            ("hdfs.provider", "jvm"),
+            ("hdfs.native", "true"),
+        ])));
+    }
+}
+
 fn opendal_error(operation: impl AsRef<str>, path: impl AsRef<str>, e: opendal::Error) -> FsError {
     let not_found = e.kind() == ErrorKind::NotFound;
     storage_error(operation, path, e, not_found)
@@ -547,15 +592,9 @@ impl OpendalFileSystem {
 
     #[cfg(any(feature = "opendal-hdfs", feature = "opendal-hdfs-native"))]
     fn use_hdfs_native(conf: &HashMap<String, String>) -> bool {
-        let explicit_backend = conf
-            .get("hdfs.provider")
-            .or_else(|| conf.get("hdfs.backend"))
-            .or_else(|| conf.get("opendal.hdfs.driver"));
-
-        if let Some(value) = explicit_backend {
-            if value.eq_ignore_ascii_case("native") || value.eq_ignore_ascii_case("hdfs-native") {
-                return true;
-            }
+        if let Some(value) = conf.get("hdfs.provider") {
+            return value.eq_ignore_ascii_case("native")
+                || value.eq_ignore_ascii_case("hdfs-native");
         }
 
         conf.get("hdfs.native")
@@ -634,6 +673,8 @@ impl OpendalFileSystem {
     ///
     /// Note: HdfsNative uses system-level Kerberos configuration via environment variables.
     /// Supported configurations:
+    /// - hdfs.provider: Set to "native" to select this backend when both JVM
+    ///   and native HDFS providers are compiled in
     /// - hdfs.namenode: NameNode address (required)
     /// - hdfs.root: Root path (default: "/")
     /// - hdfs.kerberos.krb5_conf: Path to krb5.conf file

--- a/curvine-libsdk/Cargo.toml
+++ b/curvine-libsdk/Cargo.toml
@@ -38,3 +38,4 @@ oss-hdfs = ["internal-oss-hdfs-jindo"]
 curvine-sdk-core = { workspace = true }
 curvine-libsdk-java = { workspace = true, optional = true }
 curvine-libsdk-python = { workspace = true, optional = true }
+libc = { workspace = true }

--- a/curvine-libsdk/README.md
+++ b/curvine-libsdk/README.md
@@ -109,7 +109,9 @@ python3 curvine-libsdk/python/test/curvineFileSystemTest.py
 
 ## Java SDK
 
-JDK **8**, Maven **≥ 3.8.1**. From workspace root, **`make build`** (with **`java`** in the package set) builds the JNI native copy and **`curvine-hadoop-*.jar`** under **`build/dist/lib/`**. JNI library name must match **`CurvineNative.getLibraryName()`** (see `java/native/`). Put the matching **`.so`** in **`build/dist/lib/`** next to the JAR and ensure **`java.library.path`** includes that directory (`bin/dfs` wrappers often set this).
+JDK **8**, Maven **≥ 3.8.1**. From workspace root, **`make build`** (with **`java`** in the package set) builds the JNI native copy and **`curvine-hadoop-*.jar`** under **`build/dist/lib/`**. On Linux, `CurvineNative` resolves native libraries using an ordered candidate list: the detected `<distribution><major>` name, then `linux`, `centos7`, `amzn2`, `alinux3`, and `rocky9` for the detected architecture, followed by the generic `x86` library name where applicable. Package the names produced by the native build under `java/native/` and ensure **`java.library.path`** includes the directory containing them (`bin/dfs` wrappers often set this). This fallback order lets one jar run on distributions without a dedicated native filename, provided the fallback `.so` is present.
+
+The canonical HDFS backend selector is `hdfs.provider=native` (or `jvm` for the JVM-backed OpenDAL HDFS provider). The legacy boolean `hdfs.native=true` remains supported when `hdfs.provider` is absent.
 
 **`cannot allocate memory in static TLS block`** (large JNI `.so` + glibc): load from a real **`build/dist/lib`** path first (`CurvineNative` scans `java.library.path` entries); if it still fails, try preloading **`LD_PRELOAD`** with the same **`libcurvine_libsdk_<os>_<arch>_64.so`**, or use a host/OS image validated for Curvine JNI.
 

--- a/curvine-libsdk/java/pom.xml
+++ b/curvine-libsdk/java/pom.xml
@@ -23,7 +23,7 @@
     <groupId>io.curvine</groupId>
     <description>Hadoop FileSystem implementation for Curvine</description>
     <artifactId>curvine-hadoop</artifactId>
-    <version>0.2.0</version>
+    <version>0.2.2</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -35,9 +35,9 @@
         <scala.version>2.12.18</scala.version>
         <scala.compat.version>2.12</scala.compat.version>
         <dependency.scope>compile</dependency.scope>
-        <hadoop.version>3.4.0</hadoop.version>
         <protobuf.version>3.25.7</protobuf.version>
         <hadoop.version>3.3.4</hadoop.version>
+        <shade.prefix>curvine_shaded</shade.prefix>
     </properties>
 
     <dependencies>
@@ -73,13 +73,48 @@
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
             <version>${hadoop.version}</version>
-            <scope>${dependency.scope}</scope>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-hdfs-client</artifactId>
             <version>${hadoop.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-cli</groupId>
+            <artifactId>commons-cli</artifactId>
+            <version>1.5.0</version>
+            <scope>${dependency.scope}</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.16.1</version>
+            <scope>${dependency.scope}</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.14.0</version>
+            <scope>${dependency.scope}</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+            <version>1.3.1</version>
+            <scope>${dependency.scope}</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-recipes</artifactId>
+            <version>4.2.0</version>
             <scope>${dependency.scope}</scope>
         </dependency>
 
@@ -132,6 +167,9 @@
         <resources>
             <resource>
                 <directory>${project.basedir}/src/main/resources</directory>
+                <excludes>
+                    <exclude>log4j.properties</exclude>
+                </excludes>
             </resource>
             <resource>
                 <!--native is not included in the code. After compiling curvine on the corresponding platform, put the libsdk package in the native directory and recompile java -->
@@ -153,6 +191,16 @@
         </extensions>
 
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.4.2</version>
+                <configuration>
+                    <excludes>
+                        <exclude>io/curvine/bench/**</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
@@ -247,10 +295,18 @@
                                 <exclude>META-INF/*.SF</exclude>
                                 <exclude>META-INF/*.DSA</exclude>
                                 <exclude>META-INF/*.RSA</exclude>
+                                <exclude>META-INF/versions/**</exclude>
                                 <exclude>META-INF/maven/**</exclude>
+                                <exclude>module-info.class</exclude>
+                                <exclude>log4j.properties</exclude>
+                                <exclude>javax/**</exclude>
+                                <exclude>jakarta/**</exclude>
                             </excludes>
                         </filter>
                     </filters>
+                    <transformers>
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                    </transformers>
                 </configuration>
                 <executions>
                     <execution>
@@ -262,6 +318,11 @@
                         <configuration>
                             <shadedArtifactAttached>true</shadedArtifactAttached>
                             <shadedClassifierName>shade</shadedClassifierName>
+                            <artifactSet>
+                                <excludes>
+                                    <exclude>org.scala-lang:scala-library</exclude>
+                                </excludes>
+                            </artifactSet>
                         </configuration>
                     </execution>
 
@@ -275,16 +336,123 @@
                         <configuration>
                             <shadedArtifactAttached>true</shadedArtifactAttached>
                             <shadedClassifierName>client</shadedClassifierName>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                        <exclude>META-INF/versions/**</exclude>
+                                        <exclude>META-INF/maven/**</exclude>
+                                        <exclude>module-info.class</exclude>
+                                        <exclude>log4j.properties</exclude>
+                                        <exclude>org/slf4j/impl/**</exclude>
+                                        <exclude>org/apache/log4j/**</exclude>
+                                        <exclude>org/apache/hadoop/**</exclude>
+                                        <exclude>io/curvine/S3aProxyFileSystem.class</exclude>
+                                        <exclude>scala/**</exclude>
+                                        <exclude>io/curvine/bench/**</exclude>
+                                        <exclude>javax/**</exclude>
+                                        <exclude>jakarta/**</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
                             <artifactSet>
-                                <includes>
-                                    <include>com.google.protobuf:protobuf-java</include>
-                                    <include>com.google.protobuf:protobuf-java-util</include>
-                                </includes>
+                                <excludes>
+                                    <exclude>org.scala-lang:scala-library</exclude>
+                                    <exclude>org.apache.hadoop:*</exclude>
+                                    <exclude>org.apache.hadoop.thirdparty:*</exclude>
+                                    <exclude>org.slf4j:slf4j-api</exclude>
+                                    <exclude>org.slf4j:slf4j-log4j12</exclude>
+                                    <exclude>org.slf4j:slf4j-reload4j</exclude>
+                                    <exclude>org.apache.hadoop:hadoop-aws</exclude>
+                                    <exclude>com.amazonaws:aws-java-sdk-bundle</exclude>
+                                    <exclude>javax.activation:activation</exclude>
+                                    <exclude>jakarta.activation:jakarta.activation-api</exclude>
+                                    <exclude>javax.servlet:javax.servlet-api</exclude>
+                                    <exclude>javax.servlet.jsp:jsp-api</exclude>
+                                    <exclude>javax.ws.rs:jsr311-api</exclude>
+                                    <exclude>javax.xml.bind:jaxb-api</exclude>
+                                    <exclude>javax.xml.stream:stax-api</exclude>
+                                    <exclude>javax.el:javax.el-api</exclude>
+                                    <exclude>org.glassfish:javax.el</exclude>
+                                    <exclude>log4j:log4j</exclude>
+                                    <exclude>ch.qos.reload4j:reload4j</exclude>
+                                </excludes>
                             </artifactSet>
                             <relocations>
                                 <relocation>
                                     <pattern>com.google.protobuf</pattern>
-                                    <shadedPattern>curvine_shaded.com.google.protobuf</shadedPattern>
+                                    <shadedPattern>${shade.prefix}.com.google.protobuf</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.google.gson</pattern>
+                                    <shadedPattern>${shade.prefix}.com.google.gson</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.commons</pattern>
+                                    <shadedPattern>${shade.prefix}.org.apache.commons</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>commons-logging</pattern>
+                                    <shadedPattern>${shade.prefix}.commons.logging</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.google.common</pattern>
+                                    <shadedPattern>${shade.prefix}.com.google.common</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.google.thirdparty</pattern>
+                                    <shadedPattern>${shade.prefix}.com.google.thirdparty</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.google.re2j</pattern>
+                                    <shadedPattern>${shade.prefix}.com.google.re2j</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.google.errorprone</pattern>
+                                    <shadedPattern>${shade.prefix}.com.google.errorprone</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.google.j2objc</pattern>
+                                    <shadedPattern>${shade.prefix}.com.google.j2objc</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.fasterxml</pattern>
+                                    <shadedPattern>${shade.prefix}.com.fasterxml</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.codehaus.jackson</pattern>
+                                    <shadedPattern>${shade.prefix}.org.codehaus.jackson</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.codehaus.stax2</pattern>
+                                    <shadedPattern>${shade.prefix}.org.codehaus.stax2</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.codehaus.jettison</pattern>
+                                    <shadedPattern>${shade.prefix}.org.codehaus.jettison</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.curator</pattern>
+                                    <shadedPattern>${shade.prefix}.org.apache.curator</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.zookeeper</pattern>
+                                    <shadedPattern>${shade.prefix}.org.apache.zookeeper</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.http</pattern>
+                                    <shadedPattern>${shade.prefix}.org.apache.http</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.checkerframework</pattern>
+                                    <shadedPattern>${shade.prefix}.org.checkerframework</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.codehaus.mojo</pattern>
+                                    <shadedPattern>${shade.prefix}.org.codehaus.mojo</shadedPattern>
                                 </relocation>
                             </relocations>
                         </configuration>

--- a/curvine-libsdk/java/pom.xml
+++ b/curvine-libsdk/java/pom.xml
@@ -87,7 +87,8 @@
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
             <version>1.5.0</version>
-            <scope>${dependency.scope}</scope>
+            <!-- CLI is used only by the excluded benchmark entry points. -->
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/curvine-libsdk/java/src/main/java/io/curvine/CurvineFallbackInputStream.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/CurvineFallbackInputStream.java
@@ -17,7 +17,6 @@ package io.curvine;
 import java.io.EOFException;
 import java.io.IOException;
 import java.util.function.Supplier;
-import javax.annotation.Nonnull;
 import org.apache.hadoop.fs.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,13 +55,13 @@ public class CurvineFallbackInputStream extends FSInputStream {
     }
 
     @Override
-    public int read(@Nonnull byte[] buf) throws IOException {
+    public int read(byte[] buf) throws IOException {
         checkClosed();
         return read(buf, 0, buf.length);
     }
 
     @Override
-    public int read(@Nonnull byte[] buf, int offset, int length) throws IOException {
+    public int read(byte[] buf, int offset, int length) throws IOException {
         if (ufsInputStream != null) {
             return ufsInputStream.read(buf, offset, length);
         }

--- a/curvine-libsdk/java/src/main/java/io/curvine/CurvineFsStat.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/CurvineFsStat.java
@@ -14,7 +14,6 @@
 
 package io.curvine;
 
-import io.curvine.bench.Utils;
 import io.curvine.proto.GetFilesystemInfoResponse;
 import io.curvine.proto.WorkerInfoProto;
 import org.apache.commons.lang3.StringUtils;
@@ -60,12 +59,12 @@ public class CurvineFsStat extends FsStatus {
             builder.append("\n");
         }
 
-        builder.append(String.format("%20s: %s\n", "capacity", Utils.bytesToString(info.getCapacity())));
+        builder.append(String.format("%20s: %s\n", "capacity", CurvineJavaUtils.bytesToString(info.getCapacity())));
 
         String available = String.format(
                 "%20s: %s (%.2f%%)\n",
                 "available",
-                Utils.bytesToString(info.getAvailable()),
+                CurvineJavaUtils.bytesToString(info.getAvailable()),
                 getPercent(info.getAvailable(), info.getCapacity())
         );
         builder.append(available);
@@ -73,7 +72,7 @@ public class CurvineFsStat extends FsStatus {
         String used = String.format(
                 "%20s: %s (%.2f%%)\n",
                 "fs_used",
-                Utils.bytesToString(info.getFsUsed()),
+                CurvineJavaUtils.bytesToString(info.getFsUsed()),
                 getPercent(info.getFsUsed(), info.getCapacity())
         );
         builder.append(used);
@@ -82,16 +81,16 @@ public class CurvineFsStat extends FsStatus {
         // writes (Live workers only). Absent on legacy masters, so guard with
         // hasAllocatableCapacity() to avoid printing a misleading 0.
         if (info.hasAllocatableCapacity()) {
-            builder.append(String.format("%20s: %s\n", "allocatable_capacity", Utils.bytesToString(info.getAllocatableCapacity())));
+            builder.append(String.format("%20s: %s\n", "allocatable_capacity", CurvineJavaUtils.bytesToString(info.getAllocatableCapacity())));
             builder.append(String.format(
                     "%20s: %s (%.2f%%)\n",
                     "allocatable_available",
-                    Utils.bytesToString(info.getAllocatableAvailable()),
+                    CurvineJavaUtils.bytesToString(info.getAllocatableAvailable()),
                     getPercent(info.getAllocatableAvailable(), info.getAllocatableCapacity())
             ));
         }
 
-        builder.append(String.format("%20s: %s\n", "non_fs_used", Utils.bytesToString(info.getNonFsUsed())));
+        builder.append(String.format("%20s: %s\n", "non_fs_used", CurvineJavaUtils.bytesToString(info.getNonFsUsed())));
         builder.append(String.format("%20s: %s\n", "live_worker_num", info.getLiveWorkersCount()));
         builder.append(String.format("%20s: %s\n", "lost_worker_num", info.getLostWorkersCount()));
         builder.append(String.format("%20s: %s\n", "inode_dir_num", info.getInodeDirNum()));
@@ -110,8 +109,8 @@ public class CurvineFsStat extends FsStatus {
                     "%s:%s,%s/%s (%.2f%%)",
                     worker.getAddress().getHostname(),
                     worker.getAddress().getRpcPort(),
-                    Utils.bytesToString(worker.getAvailable()),
-                    Utils.bytesToString(worker.getCapacity()),
+                    CurvineJavaUtils.bytesToString(worker.getAvailable()),
+                    CurvineJavaUtils.bytesToString(worker.getCapacity()),
                     getPercent(worker.getAvailable(), worker.getCapacity())
             );
 
@@ -153,7 +152,7 @@ public class CurvineFsStat extends FsStatus {
                     "%s:%s  %s",
                     worker.getAddress().getHostname(),
                     worker.getAddress().getRpcPort(),
-                    Utils.bytesToString(worker.getCapacity())
+                    CurvineJavaUtils.bytesToString(worker.getCapacity())
             );
             builder.append(String.format("%s\n", str));
         }
@@ -169,7 +168,7 @@ public class CurvineFsStat extends FsStatus {
                     "%s:%s  %s",
                     worker.getAddress().getHostname(),
                     worker.getAddress().getRpcPort(),
-                    Utils.bytesToString(worker.getFsUsed())
+                    CurvineJavaUtils.bytesToString(worker.getFsUsed())
             );
             builder.append(String.format("%s\n", str));
         }
@@ -185,7 +184,7 @@ public class CurvineFsStat extends FsStatus {
                     "%s:%s  %s",
                     worker.getAddress().getHostname(),
                     worker.getAddress().getRpcPort(),
-                    Utils.bytesToString(worker.getAvailable())
+                    CurvineJavaUtils.bytesToString(worker.getAvailable())
             );
             builder.append(String.format("%s\n", str));
         }

--- a/curvine-libsdk/java/src/main/java/io/curvine/CurvineInputStream.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/CurvineInputStream.java
@@ -17,8 +17,6 @@ package io.curvine;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
-import javax.annotation.Nonnull;
-
 import org.apache.hadoop.fs.FSExceptionMessages;
 import org.apache.hadoop.fs.FSInputStream;
 import org.apache.hadoop.fs.FileSystem;
@@ -59,13 +57,13 @@ public class CurvineInputStream extends FSInputStream {
     }
 
     @Override
-    public int read(@Nonnull byte[] buf) throws IOException {
+    public int read(byte[] buf) throws IOException {
         checkClosed();
         return read(buf, 0, buf.length);
     }
 
     @Override
-    public int read(@Nonnull byte[] buf, int offset, int length) throws IOException {
+    public int read(byte[] buf, int offset, int length) throws IOException {
         checkClosed();
 
         if (length == 0) {

--- a/curvine-libsdk/java/src/main/java/io/curvine/CurvineJavaUtils.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/CurvineJavaUtils.java
@@ -1,0 +1,184 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.curvine;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+
+import java.io.File;
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.math.RoundingMode;
+import java.nio.file.Paths;
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class CurvineJavaUtils {
+    private static final Pattern BYTE_SIZE_PATTERN =
+            Pattern.compile("^([+-]?(?:\\d+(?:\\.\\d*)?|\\.\\d+))\\s*([a-zA-Z]*)$");
+
+    private CurvineJavaUtils() {}
+
+    public static String bytesToString(long size) {
+        return bytesToString(BigIntegerCompat.fromLong(size));
+    }
+
+    public static String bytesToString(BigIntegerCompat size) {
+        final long eib = 1L << 60;
+        final long pib = 1L << 50;
+        final long tib = 1L << 40;
+        final long gib = 1L << 30;
+        final long mib = 1L << 20;
+        final long kib = 1L << 10;
+
+        if (size.compareTo(BigIntegerCompat.fromLong(1L << 11).multiply(eib)) >= 0) {
+            return new BigDecimal(size.toString(), new MathContext(3, RoundingMode.HALF_UP)) + " B";
+        }
+
+        BigDecimal value;
+        String unit;
+        if (size.compareTo(BigIntegerCompat.fromLong(2L * eib)) >= 0) {
+            value = new BigDecimal(size.toString()).divide(BigDecimal.valueOf(eib), MathContext.DECIMAL64);
+            unit = "EB";
+        } else if (size.compareTo(BigIntegerCompat.fromLong(2L * pib)) >= 0) {
+            value = new BigDecimal(size.toString()).divide(BigDecimal.valueOf(pib), MathContext.DECIMAL64);
+            unit = "PB";
+        } else if (size.compareTo(BigIntegerCompat.fromLong(2L * tib)) >= 0) {
+            value = new BigDecimal(size.toString()).divide(BigDecimal.valueOf(tib), MathContext.DECIMAL64);
+            unit = "TB";
+        } else if (size.compareTo(BigIntegerCompat.fromLong(2L * gib)) >= 0) {
+            value = new BigDecimal(size.toString()).divide(BigDecimal.valueOf(gib), MathContext.DECIMAL64);
+            unit = "GB";
+        } else if (size.compareTo(BigIntegerCompat.fromLong(2L * mib)) >= 0) {
+            value = new BigDecimal(size.toString()).divide(BigDecimal.valueOf(mib), MathContext.DECIMAL64);
+            unit = "MB";
+        } else if (size.compareTo(BigIntegerCompat.fromLong(2L * kib)) >= 0) {
+            value = new BigDecimal(size.toString()).divide(BigDecimal.valueOf(kib), MathContext.DECIMAL64);
+            unit = "KB";
+        } else {
+            value = new BigDecimal(size.toString());
+            unit = "B";
+        }
+
+        return String.format(Locale.US, "%.1f%s", value, unit);
+    }
+
+    public static long byteFromString(String str) {
+        if (str == null) {
+            throw new IllegalArgumentException("Size string must not be null");
+        }
+
+        Matcher matcher = BYTE_SIZE_PATTERN.matcher(str.trim());
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException("Invalid size string: " + str);
+        }
+
+        BigDecimal value = new BigDecimal(matcher.group(1));
+        if (value.signum() < 0) {
+            throw new IllegalArgumentException("Size string must not be negative: " + str);
+        }
+
+        BigDecimal bytes = value.multiply(BigDecimal.valueOf(byteUnitMultiplier(matcher.group(2))));
+        try {
+            return bytes.setScale(0, RoundingMode.HALF_UP).longValueExact();
+        } catch (ArithmeticException e) {
+            throw new IllegalArgumentException("Size string is out of long range: " + str, e);
+        }
+    }
+
+    private static long byteUnitMultiplier(String unit) {
+        String normalized = unit == null ? "" : unit.trim().toUpperCase(Locale.ROOT);
+        switch (normalized) {
+            case "":
+            case "B":
+            case "BYTE":
+            case "BYTES":
+                return 1L;
+            case "K":
+            case "KB":
+            case "KIB":
+                return 1L << 10;
+            case "M":
+            case "MB":
+            case "MIB":
+                return 1L << 20;
+            case "G":
+            case "GB":
+            case "GIB":
+                return 1L << 30;
+            case "T":
+            case "TB":
+            case "TIB":
+                return 1L << 40;
+            case "P":
+            case "PB":
+            case "PIB":
+                return 1L << 50;
+            case "E":
+            case "EB":
+            case "EIB":
+                return 1L << 60;
+            default:
+                throw new IllegalArgumentException("Unsupported size unit: " + unit);
+        }
+    }
+
+    public static Configuration getCurvineConf() {
+        String confDir = System.getProperty("curvine.conf.dir");
+        Configuration conf = new Configuration(false);
+        File file = new File(Paths.get(confDir, "curvine-site.xml").toString());
+        conf.addResource(new Path(file.getPath()));
+
+        if (conf.get("fs.cv.impl") == null) {
+            conf.set("fs.cv.impl", "io.curvine.CurvineFileSystem");
+        }
+
+        if (conf.get("fs.AbstractFileSystem.cv.impl") == null) {
+            conf.set("fs.AbstractFileSystem.cv.impl", "io.curvine.CurvineAbstractFileSystem");
+        }
+
+        return conf;
+    }
+
+    /**
+     * Small immutable wrapper to keep the utility Java-only and avoid pulling
+     * scala-library into runtime jars for size formatting helpers.
+     */
+    public static final class BigIntegerCompat {
+        private final java.math.BigInteger value;
+
+        private BigIntegerCompat(java.math.BigInteger value) {
+            this.value = value;
+        }
+
+        public static BigIntegerCompat fromLong(long value) {
+            return new BigIntegerCompat(java.math.BigInteger.valueOf(value));
+        }
+
+        public BigIntegerCompat multiply(long value) {
+            return new BigIntegerCompat(this.value.multiply(java.math.BigInteger.valueOf(value)));
+        }
+
+        public int compareTo(BigIntegerCompat other) {
+            return this.value.compareTo(other.value);
+        }
+
+        @Override
+        public String toString() {
+            return value.toString();
+        }
+    }
+}

--- a/curvine-libsdk/java/src/main/java/io/curvine/CurvineJavaUtils.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/CurvineJavaUtils.java
@@ -138,8 +138,17 @@ public final class CurvineJavaUtils {
 
     public static Configuration getCurvineConf() {
         String confDir = System.getProperty("curvine.conf.dir");
+        if (confDir == null || confDir.trim().isEmpty()) {
+            throw new IllegalArgumentException("System property curvine.conf.dir must be set");
+        }
+
         Configuration conf = new Configuration(false);
         File file = new File(Paths.get(confDir, "curvine-site.xml").toString());
+        if (!file.isFile()) {
+            throw new IllegalArgumentException("curvine-site.xml was not found under curvine.conf.dir: "
+                    + file.getAbsolutePath());
+        }
+
         conf.addResource(new Path(file.getPath()));
 
         if (conf.get("fs.cv.impl") == null) {

--- a/curvine-libsdk/java/src/main/java/io/curvine/CurvineNative.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/CurvineNative.java
@@ -15,7 +15,6 @@
 package io.curvine;
 
 import java.nio.Buffer;
-import java.nio.charset.StandardCharsets;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -25,6 +24,9 @@ import java.io.*;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.regex.Pattern;
 
 public class CurvineNative {
@@ -36,9 +38,10 @@ public class CurvineNative {
     public static final String LIBRARY_PATH = "java.library.path";
     public static final String NATIVE_WORKDIR = "curvine.native.workdir";
 
-    public static String OS_RELEASE_FILE = "/etc/os-release";
-    public static final String LINUX_ID_PREFIX = "ID=";
-    public static final String LINUX_VERSION_PREFIX = "VERSION_ID=";
+    public static String OS_RELEASE_FILE = CurvineNativeLibraryResolver.OS_RELEASE_FILE;
+    public static final String LINUX_ID_PREFIX = CurvineNativeLibraryResolver.LINUX_ID_PREFIX;
+    public static final String LINUX_VERSION_PREFIX = CurvineNativeLibraryResolver.LINUX_VERSION_PREFIX;
+    private static final String JINDOSDK_SONAME = "libjindosdk_c.so.6";
 
     // Split java.version on non-digit chars:
     private static final int majorVersion =
@@ -88,31 +91,35 @@ public class CurvineNative {
     }
 
     public static String getLibraryName() {
+        return getLibraryNames()[0];
+    }
+
+    public static String[] getLibraryNames() {
         String sysOs = System.getProperty("os.name").toLowerCase();
-        String sysArch = System.getProperty("os.arch").toLowerCase();
+        String arch = getNativeArch();
+        String osVersion = isLinux() ? getOsVersion() : null;
 
-        // Determine platform type
-        String arch;
-        if (sysArch.contains("arm") || sysArch.contains("aarch")) {
-            arch = "aarch";
-        } else if (sysArch.contains("x86") || sysArch.contains("amd")) {
-            arch = "x86";
-        } else {
-            throw new RuntimeException("Unsupported CPU architecture: " + sysArch);
-        }
+        return getLibraryNames(sysOs, osVersion, arch);
+    }
 
-        if (!sysArch.contains("64")) {
-            throw new RuntimeException("Currently only supports 64-bit systems");
-        }
+    static String[] getLibraryNames(String sysOs, String osVersion, String arch) {
+        return CurvineNativeLibraryResolver.getLibraryNames(sysOs, osVersion, arch);
+    }
 
-        if (sysOs.contains("win")) {
-            return "curvine_libsdk.dll";
-        } else if (sysOs.contains("linux")) {
-            String osVersion = getOsVersion();
-            return String.format("libcurvine_libsdk_%s_%s_64.so", osVersion, arch);
-        } else {
-            throw new RuntimeException("Unsupported operating systems: " + sysOs);
+    private static String getNativeArch() {
+        return CurvineNativeLibraryResolver.getNativeArch(
+                System.getProperty("os.arch").toLowerCase());
+    }
+
+    private static boolean isLinux() {
+        return CurvineNativeLibraryResolver.isLinux(System.getProperty("os.name").toLowerCase());
+    }
+
+    private static String getJindoLibraryResourceName() {
+        if (!isLinux()) {
+            return null;
         }
+        return String.format("libjindosdk_c_linux_%s_64.so.6", getNativeArch());
     }
 
     public static String getOsVersion() {
@@ -120,37 +127,7 @@ public class CurvineNative {
     }
 
     public static String getOsVersion(String path) {
-        File file = new File(path);
-        if (!file.exists()) {
-            return "unknown";
-        }
-
-        // Use try-with-resources to ensure BufferedReader is properly closed
-        try (BufferedReader reader = new BufferedReader(
-                new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8))) {
-            String line;
-            String id = null;
-            String version = null;
-            while ((line = reader.readLine()) != null) {
-                if (line.startsWith(LINUX_ID_PREFIX)) {
-                    id = normalizeOsReleaseVariableValue(line.substring(LINUX_ID_PREFIX.length()));
-                } else if (line.startsWith(LINUX_VERSION_PREFIX)) {
-                    version = normalizeOsReleaseVariableValue(line.substring(LINUX_VERSION_PREFIX.length()));
-                    String[] split = version.split("\\.");
-                    if (split.length > 0) {
-                        version = split[0];
-                    }
-                }
-            }
-
-            if (id == null || version == null) {
-                throw new RuntimeException("No os version was parsed");
-            }
-            return id.toLowerCase() + version;
-        } catch (Exception e) {
-            LOGGER.warn("Failed to parse the os version", e);
-            return "unknown";
-        }
+        return CurvineNativeLibraryResolver.getOsVersion(path);
     }
 
     /**
@@ -195,71 +172,138 @@ public class CurvineNative {
      * loading from a real filesystem path before copying to tmp (helps some TLS / dlopen cases).
      */
     public static void load() {
-        String libraryName = getLibraryName();
+        String[] libraryNames = getLibraryNames();
         Throwable lastFailure = null;
+        List<String> failures = new ArrayList<>();
 
-        try {
-            System.loadLibrary(loadLibraryLookupName(libraryName));
-            LOGGER.info("Loaded native library {} via System.loadLibrary", libraryName);
-            return;
-        } catch (UnsatisfiedLinkError e) {
-            LOGGER.debug("System.loadLibrary failed for {}: {}", libraryName, e.toString());
+        for (String libraryName : libraryNames) {
+            try {
+                System.loadLibrary(loadLibraryLookupName(libraryName));
+                LOGGER.info("Loaded native library {} via System.loadLibrary", libraryName);
+                return;
+            } catch (UnsatisfiedLinkError e) {
+                lastFailure = e;
+                failures.add("System.loadLibrary(" + libraryName + "): " + e);
+                LOGGER.debug("System.loadLibrary failed for {}: {}", libraryName, e.toString());
+            }
+        }
+
+        for (String libraryName : libraryNames) {
+            try {
+                if (loadFromLibraryPathDirectories(libraryName)) {
+                    return;
+                }
+            } catch (Throwable e) {
+                lastFailure = e;
+                failures.add("java.library.path(" + libraryName + "): " + e);
+                LOGGER.warn("java.library.path directory scan failed for {}", libraryName, e);
+            }
         }
 
         try {
-            if (loadFromLibraryPathDirectories(libraryName)) {
-                return;
+            File extractionDir = createNativeExtractionDir();
+            String jindoPath = loadJindoLibraryFromJar(extractionDir);
+            if (jindoPath != null) {
+                System.load(jindoPath);
+                LOGGER.info("Loaded JindoSDK native dependency from jar extract {}", jindoPath);
+            }
+
+            for (String libraryName : libraryNames) {
+                if (!hasJarResource(libraryName)) {
+                    LOGGER.debug("Native library {} was not found inside JAR", libraryName);
+                    continue;
+                }
+                try {
+                    File extracted = extractLibraryFromJar(libraryName, new File(extractionDir, libraryName));
+                    System.load(extracted.getAbsolutePath());
+                    LOGGER.info("Loaded native library {} from jar extract {}", libraryName,
+                            extracted.getAbsolutePath());
+                    return;
+                } catch (Throwable e) {
+                    lastFailure = e;
+                    failures.add("jar(" + libraryName + "): " + e);
+                    LOGGER.warn("Failed to load {} from jar", libraryName, e);
+                }
             }
         } catch (Throwable e) {
             lastFailure = e;
-            LOGGER.warn("java.library.path directory scan failed for {}", libraryName, e);
-        }
-
-        try {
-            String extracted = loadLibraryFromJar(libraryName);
-            System.load(extracted);
-            LOGGER.info("Loaded native library {} from jar extract {}", libraryName, extracted);
-            return;
-        } catch (Throwable e) {
-            lastFailure = e;
-            LOGGER.warn("Failed to load {} from jar", libraryName, e);
+            failures.add("jar extraction setup: " + e);
+            LOGGER.warn("Failed to load native libraries from jar", e);
         }
 
         RuntimeException rte = new RuntimeException(
-                "Could not load native library " + libraryName, lastFailure);
+                "Could not load native library. Tried [" + StringUtils.join(libraryNames, ", ")
+                        + "]. Failures: " + failures, lastFailure);
         LOGGER.error(rte.getMessage(), lastFailure);
         throw rte;
     }
 
     public static String loadLibraryFromJar(String libraryName) throws IOException {
+        return extractLibraryFromJar(
+                libraryName,
+                new File(createNativeExtractionDir(), libraryName)
+        ).getAbsolutePath();
+    }
+
+    private static File createNativeExtractionDir() throws IOException {
+        File dir = Files.createTempDirectory(WORKDIR.toPath(), "curvine-native-").toFile();
+        dir.deleteOnExit();
+        return dir;
+    }
+
+    private static String loadJindoLibraryFromJar(File extractionDir) throws IOException {
+        String resourceName = getJindoLibraryResourceName();
+        if (resourceName == null) {
+            return null;
+        }
+
+        if (!hasJarResource(resourceName)) {
+            LOGGER.debug("JindoSDK native dependency {} was not found inside JAR", resourceName);
+            return null;
+        }
+
+        return extractLibraryFromJar(resourceName, new File(extractionDir, JINDOSDK_SONAME))
+                .getAbsolutePath();
+    }
+
+    private static boolean hasJarResource(String resourceName) {
+        return CurvineNative.class.getClassLoader().getResource(resourceName) != null;
+    }
+
+    private static File extractLibraryFromJar(String libraryName, File outputFile) throws IOException {
         // Load from jar package.
-        final File temp = File.createTempFile(
-                FilenameUtils.getBaseName(libraryName),
-                "." + FilenameUtils.getExtension(libraryName),
-                WORKDIR
-        );
-        if (temp.exists() && !temp.delete()) {
-            throw new RuntimeException("File: " + temp.getAbsolutePath()
-                    + " already exists and cannot be removed.");
-        }
-        if (!temp.createNewFile()) {
-            throw new RuntimeException("File: " + temp.getAbsolutePath()
-                    + " could not be created.");
+        final File parent = outputFile.getParentFile();
+        if (parent != null && !parent.exists() && !parent.mkdirs()) {
+            throw new IOException("Native extraction directory could not be created: "
+                    + parent.getAbsolutePath());
         }
 
-        if (!temp.exists()) {
-            throw new RuntimeException("File " + temp.getAbsolutePath() + " does not exist.");
-        } else {
-            temp.deleteOnExit();
-        }
-
+        File temp = File.createTempFile(outputFile.getName(), ".tmp", parent);
+        temp.deleteOnExit();
         try (final InputStream is = CurvineNative.class.getClassLoader().getResourceAsStream(libraryName)) {
             if (is == null) {
                 throw new RuntimeException(libraryName + " was not found inside JAR.");
             }
             copyUninterruptibly(is, temp);
+            if (outputFile.exists() && !outputFile.delete()) {
+                throw new IOException("Native output file could not be replaced: "
+                        + outputFile.getAbsolutePath());
+            }
+            if (!temp.renameTo(outputFile)) {
+                try (FileInputStream in = new FileInputStream(temp)) {
+                    copyUninterruptibly(in, outputFile);
+                }
+            }
+        } finally {
+            if (temp.exists() && !temp.delete()) {
+                LOGGER.debug("Failed to delete temporary native extraction file {}", temp.getAbsolutePath());
+            }
         }
-        return temp.getAbsolutePath();
+
+        outputFile.setReadable(true);
+        outputFile.setExecutable(true);
+        outputFile.deleteOnExit();
+        return outputFile;
     }
 
     /**
@@ -305,8 +349,7 @@ public class CurvineNative {
     }
 
     public static String normalizeOsReleaseVariableValue(String value) {
-        // Variable assignment values may be enclosed in double or single quotes.
-        return value.trim().replaceAll("[\"']", "");
+        return CurvineNativeLibraryResolver.normalizeOsReleaseVariableValue(value);
     }
 
     public static native long newFilesystem(String conf) throws IOException;

--- a/curvine-libsdk/java/src/main/java/io/curvine/CurvineNativeLibraryResolver.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/CurvineNativeLibraryResolver.java
@@ -1,0 +1,116 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.curvine;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+final class CurvineNativeLibraryResolver {
+    private static final Logger LOGGER = LoggerFactory.getLogger(CurvineNativeLibraryResolver.class);
+
+    static final String OS_RELEASE_FILE = "/etc/os-release";
+    static final String LINUX_ID_PREFIX = "ID=";
+    static final String LINUX_VERSION_PREFIX = "VERSION_ID=";
+
+    private CurvineNativeLibraryResolver() {
+    }
+
+    static String[] getLibraryNames(String sysOs, String osVersion, String arch) {
+        if (sysOs.contains("win")) {
+            return new String[] {"curvine_libsdk.dll"};
+        } else if (sysOs.contains("linux")) {
+            String archSuffix = arch + "_64";
+            Set<String> libraryNames = new LinkedHashSet<>();
+            if (StringUtils.isNotBlank(osVersion) && !"unknown".equalsIgnoreCase(osVersion)) {
+                libraryNames.add(String.format("libcurvine_libsdk_%s_%s.so", osVersion, archSuffix));
+            }
+            libraryNames.add(String.format("libcurvine_libsdk_linux_%s.so", archSuffix));
+            libraryNames.add(String.format("libcurvine_libsdk_centos7_%s.so", archSuffix));
+            if ("x86".equals(arch)) {
+                libraryNames.add("libcurvine_libsdk_rocky9_x86_64.so");
+                libraryNames.add("libcurvine_libsdk.so");
+            }
+            return libraryNames.toArray(new String[0]);
+        } else {
+            throw new RuntimeException("Unsupported operating systems: " + sysOs);
+        }
+    }
+
+    static String getNativeArch(String sysArch) {
+        if (!sysArch.contains("64")) {
+            throw new RuntimeException("Currently only supports 64-bit systems");
+        }
+
+        if (sysArch.contains("arm") || sysArch.contains("aarch")) {
+            return "aarch";
+        } else if (sysArch.contains("x86") || sysArch.contains("amd")) {
+            return "x86";
+        } else {
+            throw new RuntimeException("Unsupported CPU architecture: " + sysArch);
+        }
+    }
+
+    static boolean isLinux(String sysOs) {
+        return sysOs.contains("linux");
+    }
+
+    static String getOsVersion(String path) {
+        File file = new File(path);
+        if (!file.exists()) {
+            return "unknown";
+        }
+
+        // Use try-with-resources to ensure BufferedReader is properly closed.
+        try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8))) {
+            String line;
+            String id = null;
+            String version = null;
+            while ((line = reader.readLine()) != null) {
+                if (line.startsWith(LINUX_ID_PREFIX)) {
+                    id = normalizeOsReleaseVariableValue(line.substring(LINUX_ID_PREFIX.length()));
+                } else if (line.startsWith(LINUX_VERSION_PREFIX)) {
+                    version = normalizeOsReleaseVariableValue(line.substring(LINUX_VERSION_PREFIX.length()));
+                    String[] split = version.split("\\.");
+                    if (split.length > 0) {
+                        version = split[0];
+                    }
+                }
+            }
+
+            if (id == null || version == null) {
+                throw new RuntimeException("No os version was parsed");
+            }
+            return id.toLowerCase() + version;
+        } catch (Exception e) {
+            LOGGER.warn("Failed to parse the os version", e);
+            return "unknown";
+        }
+    }
+
+    static String normalizeOsReleaseVariableValue(String value) {
+        // Variable assignment values may be enclosed in double or single quotes.
+        return value.trim().replaceAll("[\"']", "");
+    }
+}

--- a/curvine-libsdk/java/src/main/java/io/curvine/CurvineNativeLibraryResolver.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/CurvineNativeLibraryResolver.java
@@ -47,8 +47,10 @@ final class CurvineNativeLibraryResolver {
             }
             libraryNames.add(String.format("libcurvine_libsdk_linux_%s.so", archSuffix));
             libraryNames.add(String.format("libcurvine_libsdk_centos7_%s.so", archSuffix));
+            libraryNames.add(String.format("libcurvine_libsdk_amzn2_%s.so", archSuffix));
+            libraryNames.add(String.format("libcurvine_libsdk_alinux3_%s.so", archSuffix));
+            libraryNames.add(String.format("libcurvine_libsdk_rocky9_%s.so", archSuffix));
             if ("x86".equals(arch)) {
-                libraryNames.add("libcurvine_libsdk_rocky9_x86_64.so");
                 libraryNames.add("libcurvine_libsdk.so");
             }
             return libraryNames.toArray(new String[0]);

--- a/curvine-libsdk/java/src/main/java/io/curvine/CurvineOutputStream.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/CurvineOutputStream.java
@@ -18,8 +18,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 
-import javax.annotation.Nonnull;
-
 import org.apache.hadoop.fs.Syncable;
 
 public class CurvineOutputStream extends OutputStream implements Syncable {
@@ -55,13 +53,13 @@ public class CurvineOutputStream extends OutputStream implements Syncable {
     }
 
     @Override
-    public void write(@Nonnull byte[] buf) throws IOException {
+    public void write(byte[] buf) throws IOException {
         checkClosed();
         write(buf, 0, buf.length);
     }
 
     @Override
-    public void write(@Nonnull byte[] buf, int offset, int length) throws IOException {
+    public void write(byte[] buf, int offset, int length) throws IOException {
         checkClosed();
         if (length == 0) {
             return;

--- a/curvine-libsdk/java/src/main/java/io/curvine/CurvineShell.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/CurvineShell.java
@@ -14,7 +14,6 @@
 
 package io.curvine;
 
-import io.curvine.bench.Utils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.FsShell;
@@ -52,7 +51,7 @@ public class CurvineShell {
     }
 
     public static void runFsShell(String[] args) throws Exception {
-        Configuration conf = Utils.getCurvineConf();
+        Configuration conf = CurvineJavaUtils.getCurvineConf();
         conf.setQuietMode(false);
 
         FsShell shell = new FsShell(conf);
@@ -66,7 +65,7 @@ public class CurvineShell {
     }
 
     public static void runReport(String[] args) throws Exception {
-        Configuration conf = Utils.getCurvineConf();
+        Configuration conf = CurvineJavaUtils.getCurvineConf();
         conf.setQuietMode(false);
 
         try (FileSystem fs = FileSystem.get(conf)) {

--- a/curvine-libsdk/java/src/test/java/io/curvine/CurvineJavaUtilsTest.java
+++ b/curvine-libsdk/java/src/test/java/io/curvine/CurvineJavaUtilsTest.java
@@ -1,0 +1,36 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.curvine;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class CurvineJavaUtilsTest {
+    @Test
+    public void byteFromStringParsesBinaryUnitsWithoutHadoop3RuntimeClasses() {
+        assertEquals(0L, CurvineJavaUtils.byteFromString("0"));
+        assertEquals(42L, CurvineJavaUtils.byteFromString("42"));
+        assertEquals(128L * 1024L, CurvineJavaUtils.byteFromString("128KB"));
+        assertEquals(10L * 1024L * 1024L, CurvineJavaUtils.byteFromString("10MB"));
+        assertEquals(10L * 1024L * 1024L * 1024L, CurvineJavaUtils.byteFromString("10g"));
+        assertEquals(1536L, CurvineJavaUtils.byteFromString("1.5 KB"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void byteFromStringRejectsUnknownUnits() {
+        CurvineJavaUtils.byteFromString("10XB");
+    }
+}

--- a/curvine-libsdk/java/src/test/java/io/curvine/CurvineJavaUtilsTest.java
+++ b/curvine-libsdk/java/src/test/java/io/curvine/CurvineJavaUtilsTest.java
@@ -14,11 +14,23 @@
 
 package io.curvine;
 
+import org.apache.hadoop.conf.Configuration;
 import org.junit.Test;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class CurvineJavaUtilsTest {
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
     @Test
     public void byteFromStringParsesBinaryUnitsWithoutHadoop3RuntimeClasses() {
         assertEquals(0L, CurvineJavaUtils.byteFromString("0"));
@@ -32,5 +44,57 @@ public class CurvineJavaUtilsTest {
     @Test(expected = IllegalArgumentException.class)
     public void byteFromStringRejectsUnknownUnits() {
         CurvineJavaUtils.byteFromString("10XB");
+    }
+
+    @Test
+    public void getCurvineConfSetsHadoopFileSystemImplementations() throws Exception {
+        File confDir = temporaryFolder.newFolder("curvine-conf");
+        File confFile = new File(confDir, "curvine-site.xml");
+        Files.write(confFile.toPath(), Arrays.asList("<configuration>", "</configuration>"),
+                StandardCharsets.UTF_8);
+
+        String previous = System.getProperty("curvine.conf.dir");
+        try {
+            System.setProperty("curvine.conf.dir", confDir.getAbsolutePath());
+            Configuration conf = CurvineJavaUtils.getCurvineConf();
+
+            assertEquals("io.curvine.CurvineFileSystem", conf.get("fs.cv.impl"));
+            assertEquals("io.curvine.CurvineAbstractFileSystem",
+                    conf.get("fs.AbstractFileSystem.cv.impl"));
+            assertNull(conf.get("fs.curvine.impl"));
+        } finally {
+            restoreProperty("curvine.conf.dir", previous);
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void getCurvineConfRequiresConfigurationDirectory() {
+        String previous = System.getProperty("curvine.conf.dir");
+        try {
+            System.clearProperty("curvine.conf.dir");
+            CurvineJavaUtils.getCurvineConf();
+        } finally {
+            restoreProperty("curvine.conf.dir", previous);
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void getCurvineConfRequiresCurvineSiteXml() throws Exception {
+        File confDir = temporaryFolder.newFolder("missing-curvine-conf");
+        String previous = System.getProperty("curvine.conf.dir");
+        try {
+            System.setProperty("curvine.conf.dir", confDir.getAbsolutePath());
+            CurvineJavaUtils.getCurvineConf();
+        } finally {
+            restoreProperty("curvine.conf.dir", previous);
+        }
+    }
+
+    private static void restoreProperty(String key, String value) {
+        if (value == null) {
+            System.clearProperty(key);
+        } else {
+            System.setProperty(key, value);
+        }
     }
 }

--- a/curvine-libsdk/java/src/test/java/io/curvine/LibFsTest.java
+++ b/curvine-libsdk/java/src/test/java/io/curvine/LibFsTest.java
@@ -16,9 +16,12 @@ package io.curvine;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.File;
+import java.util.Arrays;
+import java.util.List;
 
 public class LibFsTest {
     @Test
@@ -87,7 +90,22 @@ public class LibFsTest {
 
     @Test
     public void osVersion() throws Exception {
-        String ver = CurvineNative.getOsVersion("src/test/resources/os-version");
+        String ver = CurvineNativeLibraryResolver.getOsVersion("src/test/resources/os-version");
         System.out.println(ver);
+    }
+
+    @Test
+    public void linuxLibraryNamesFallBackToGenericLinux() {
+        List<String> x86 = Arrays.asList(CurvineNativeLibraryResolver.getLibraryNames("linux", "ubuntu20", "x86"));
+        Assert.assertEquals("libcurvine_libsdk_ubuntu20_x86_64.so", x86.get(0));
+        Assert.assertTrue(x86.contains("libcurvine_libsdk_linux_x86_64.so"));
+        Assert.assertTrue(x86.contains("libcurvine_libsdk_centos7_x86_64.so"));
+        Assert.assertTrue(x86.contains("libcurvine_libsdk.so"));
+
+        List<String> arm = Arrays.asList(CurvineNativeLibraryResolver.getLibraryNames("linux", "ubuntu20", "aarch"));
+        Assert.assertEquals("libcurvine_libsdk_ubuntu20_aarch_64.so", arm.get(0));
+        Assert.assertTrue(arm.contains("libcurvine_libsdk_linux_aarch_64.so"));
+        Assert.assertTrue(arm.contains("libcurvine_libsdk_centos7_aarch_64.so"));
+        Assert.assertFalse(arm.contains("libcurvine_libsdk.so"));
     }
 }

--- a/curvine-libsdk/java/src/test/java/io/curvine/LibFsTest.java
+++ b/curvine-libsdk/java/src/test/java/io/curvine/LibFsTest.java
@@ -100,12 +100,18 @@ public class LibFsTest {
         Assert.assertEquals("libcurvine_libsdk_ubuntu20_x86_64.so", x86.get(0));
         Assert.assertTrue(x86.contains("libcurvine_libsdk_linux_x86_64.so"));
         Assert.assertTrue(x86.contains("libcurvine_libsdk_centos7_x86_64.so"));
+        Assert.assertTrue(x86.contains("libcurvine_libsdk_amzn2_x86_64.so"));
+        Assert.assertTrue(x86.contains("libcurvine_libsdk_alinux3_x86_64.so"));
+        Assert.assertTrue(x86.contains("libcurvine_libsdk_rocky9_x86_64.so"));
         Assert.assertTrue(x86.contains("libcurvine_libsdk.so"));
 
         List<String> arm = Arrays.asList(CurvineNativeLibraryResolver.getLibraryNames("linux", "ubuntu20", "aarch"));
         Assert.assertEquals("libcurvine_libsdk_ubuntu20_aarch_64.so", arm.get(0));
         Assert.assertTrue(arm.contains("libcurvine_libsdk_linux_aarch_64.so"));
         Assert.assertTrue(arm.contains("libcurvine_libsdk_centos7_aarch_64.so"));
+        Assert.assertTrue(arm.contains("libcurvine_libsdk_amzn2_aarch_64.so"));
+        Assert.assertTrue(arm.contains("libcurvine_libsdk_alinux3_aarch_64.so"));
+        Assert.assertTrue(arm.contains("libcurvine_libsdk_rocky9_aarch_64.so"));
         Assert.assertFalse(arm.contains("libcurvine_libsdk.so"));
     }
 }

--- a/curvine-libsdk/src/cxx_compat.rs
+++ b/curvine-libsdk/src/cxx_compat.rs
@@ -1,0 +1,55 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::ffi::c_int;
+use std::ffi::c_void;
+
+// Older glibc releases such as CentOS 7's 2.17 do not export
+// `__cxa_thread_atexit_impl`, while newer libstdc++ static archives may
+// reference it. Provide a local fallback so JNI can still load on those hosts.
+//
+// The fallback degrades thread-local destructor timing to process-exit timing
+// via `__cxa_atexit`, which is sufficient for this SDK because we do not rely
+// on prompt TLS destructor execution for correctness.
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn __cxa_thread_atexit_impl(
+    dtor: extern "C" fn(*mut c_void),
+    obj: *mut c_void,
+    dso_symbol: *mut c_void,
+) -> c_int {
+    unsafe extern "C" {
+        fn __cxa_atexit(
+            func: extern "C" fn(*mut c_void),
+            arg: *mut c_void,
+            dso_handle: *mut c_void,
+        ) -> c_int;
+    }
+
+    // SAFETY: Mirrors the C ABI of `__cxa_atexit`. The callback and payload are
+    // provided by libstdc++ for TLS cleanup registration.
+    unsafe { __cxa_atexit(dtor, obj, dso_symbol) }
+}
+
+// glibc 2.17 does not export `gettid`, but some transitive native dependencies
+// may still reference it directly. Provide a small compatibility shim that
+// delegates to the raw syscall.
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn gettid() -> libc::pid_t {
+    // SAFETY: `SYS_gettid` takes no additional arguments and returns the
+    // calling thread id. Casting the raw syscall result to `pid_t` matches the
+    // Linux ABI used by glibc's newer `gettid` wrapper.
+    unsafe { libc::syscall(libc::SYS_gettid as libc::c_long) as libc::pid_t }
+}

--- a/curvine-libsdk/src/lib.rs
+++ b/curvine-libsdk/src/lib.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod cxx_compat;
+
 pub use curvine_sdk_core::{FilesystemConf, LibFilesystem, LibFsReader, LibFsWriter};
 
 #[cfg(feature = "rust-sdk")]

--- a/curvine-libsdk/src/lib.rs
+++ b/curvine-libsdk/src/lib.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
 mod cxx_compat;
 
 pub use curvine_sdk_core::{FilesystemConf, LibFilesystem, LibFsReader, LibFsWriter};


### PR DESCRIPTION
# Summary

Harden the Java SDK single-jar runtime packaging path for mixed Hadoop/Flink/StarRocks environments. This PR removes avoidable runtime conflicts from the client artifact, improves native library fallback/loading, and keeps JNI compatibility with older Linux baselines.

# Issue Describe / Design

Related issues: None

Root cause:
- The Java SDK client artifact could leak Hadoop/Scala/bench/javax/jakarta classes into runtime classpaths, causing conflicts with host frameworks such as Flink and StarRocks.
- Native loading relied on one exact OS-specific library name, so Ubuntu/CentOS variants could fail even when a compatible generic Linux or CentOS 7 JNI library was packaged.
- Packaged JNI libraries need Jindo runtime extraction into the same directory so `$ORIGIN` can resolve `libjindosdk_c.so.6`.
- CentOS 7 era glibc environments require static-link compatibility shims and ARM linker wrapping as well as x86.

Fix approach:
- Add Java-only helpers and move shell/stat/runtime packaging code away from Scala bench utilities.
- Tighten Maven jar/shade/client packaging rules and relocate Curvine-owned dependencies under `curvine_shaded.*`.
- Load native libraries through an ordered candidate list: exact OS first, then generic Linux/CentOS fallback; extract Jindo dependency beside the selected JNI library.
- Keep native library name resolution testable without triggering JNI loading.
- Add glibc compatibility shims for old Linux runtimes and extend the static link wrapper to ARM.
- Allow OpenDAL HDFS to select JVM or native backend through configuration while keeping existing default behavior.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-libsdk/java/pom.xml` | Harden main/shade/client packaging, mark Hadoop as provided, relocate bundled dependencies, remove bench/logging/runtime-conflict entries | Behavior change: client jar becomes safer for host-managed Hadoop/Flink/StarRocks classpaths |
| `curvine-libsdk/java/src/main/java/io/curvine/CurvineNative.java` | Add native candidate fallback and colocated Jindo extraction/loading | Behavior change: wider Linux distro compatibility and better diagnostics |
| `curvine-libsdk/java/src/main/java/io/curvine/CurvineNativeLibraryResolver.java` | Split native OS/arch library name resolution from JNI loading | Test-only path no longer requires packaged native `.so` |
| `curvine-libsdk/java/src/main/java/io/curvine/CurvineJavaUtils.java` | Add Java-only size parsing/formatting and Curvine Hadoop conf helper | Removes runtime dependency on Scala bench utility code |
| `curvine-libsdk/java/src/main/java/io/curvine/*Stream.java` | Remove `javax.annotation.Nonnull` from stream overrides | Avoids unnecessary javax dependency in client artifact |
| `crates/adapters/curvine-ufs-opendal/src/lib.rs` | Route HDFS provider selection through `hdfs.provider` / `hdfs.backend` / `hdfs.native` | Existing default remains JVM HDFS when available; native backend can be selected explicitly |
| `.cargo/config.toml`, `build/static-link-wrapper.sh`, `curvine-libsdk/src/cxx_compat.rs` | Extend static-link wrapper and add CentOS 7 compatibility symbols | Improves JNI loadability on old glibc and ARM environments |
| `Cargo.toml`, `Cargo.lock`, `curvine-libsdk/Cargo.toml` | Bump workspace/package version and add required libc dependency | Version and dependency alignment for the SDK build |
| `curvine-libsdk/java/src/test/java/io/curvine/*` | Add Java utility and native fallback coverage | Test-only impact |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `make format` | PASS | Runs project pre-commit formatting/check path, including Rust release workspace checks |
| `cargo check -p curvine-libsdk --no-default-features --features java-sdk-minimal` | PASS | Validates minimal Java SDK native feature graph |
| `mvn -B -ntp -f curvine-libsdk/java/pom.xml -Dtest=io.curvine.CurvineJavaUtilsTest,io.curvine.LibFsTest#linuxLibraryNamesFallBackToGenericLinux,io.curvine.LibFsTest#osVersion test` | PASS | 4 tests passed |
| `mvn -B -ntp -f curvine-libsdk/java/pom.xml -Prelease -DskipTests package` | PASS | Built main/client/shade jars |
| `jar tf curvine-libsdk/java/target/curvine-hadoop-0.2.2-client.jar | rg '(^scala/|^javax/|^jakarta/|^org/apache/hadoop/|^io/curvine/bench/|^META-INF/versions/|StorageSize.class)'` | PASS | No forbidden entries found |
| `jar tf curvine-libsdk/java/target/curvine-hadoop-0.2.2.jar | rg '^io/curvine/bench/'` | PASS | No forbidden bench entries found |
| `jar tf curvine-libsdk/java/target/curvine-hadoop-0.2.2-shade.jar | rg '(^scala/|^io/curvine/bench/)'` | PASS | No forbidden Scala/bench entries found |
| `javap -verbose -classpath curvine-libsdk/java/target/curvine-hadoop-0.2.2-client.jar io.curvine.CurvineNative | rg 'major version'` | PASS | Java bytecode major version 52 |
| `mvn -B -ntp -f curvine-libsdk/java/pom.xml -Dtest=io.curvine.CurvineJavaUtilsTest,io.curvine.LibFsTest test` | FAIL | `LibFsTest.jni1` requires local Curvine master on `localhost:9001/9002`; current machine has no local master, so it fails with connection refused |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None