### PR TITLE
ci(images): preinstall FoundationDB client in CI images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,31 +53,6 @@ jobs:
           rustc --version
           cargo --version
 
-      - name: Install FoundationDB client library
-        run: |
-          # curvine-mds links libfdb_c unconditionally (foundationdb crate,
-          # fdb-7_3). The client rpm ships libfdb_c.so needed at link time;
-          # embedded-fdb-include already provides the headers at build time, so
-          # only the client library is required here.
-          set -euo pipefail
-          FDB_VERSION=7.3.77
-          # Pinned SHA256 of the official release asset (supply-chain safety):
-          # verify the download before installing.
-          FDB_CLIENTS_SHA256=9255a4730655ac1a8461d8da5148a9d87c8978944188477f5b745318bb6d40ba
-          curl -fsSL -o /tmp/foundationdb-clients.rpm \
-            "https://github.com/apple/foundationdb/releases/download/${FDB_VERSION}/foundationdb-clients-${FDB_VERSION}-1.el7.x86_64.rpm"
-          echo "${FDB_CLIENTS_SHA256}  /tmp/foundationdb-clients.rpm" | sha256sum -c -
-          rpm -i --nodeps /tmp/foundationdb-clients.rpm
-          # The rpm installs libfdb_c.so under /usr/lib; also expose it under
-          # /usr/lib64 (Rocky's default 64-bit lib dir) so the linker finds it
-          # regardless of its default search paths.
-          if [ -f /usr/lib/libfdb_c.so ] && [ ! -e /usr/lib64/libfdb_c.so ]; then
-            ln -s /usr/lib/libfdb_c.so /usr/lib64/libfdb_c.so
-          fi
-          echo "/usr/lib" > /etc/ld.so.conf.d/foundationdb.conf
-          ldconfig
-          ldconfig -p | grep libfdb_c || (echo "libfdb_c not registered" && exit 1)
-      
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
         with:

--- a/curvine-docker/compile/Dockerfile_amzn2
+++ b/curvine-docker/compile/Dockerfile_amzn2
@@ -36,6 +36,32 @@ RUN yum install -y \
     fio \
     && yum clean all
 
+# 1.2. Install FoundationDB client library (x86_64)
+# Required to link libfdb_c when building curvine-mds/curvine-server
+# (foundationdb crate, fdb-7_3). The official release ships an el7 rpm for
+# x86_64 only (no aarch64 build), which is compatible with Amazon Linux 2's
+# glibc 2.26. SHA256-pinned for supply-chain safety (same pin as the CI
+# workflow used previously). shadow-utils provides groupadd/useradd needed
+# by the rpm preinstall scriptlet.
+RUN ARCH=$(uname -m) && \
+    FDB_VERSION=7.3.77 && \
+    case "${ARCH}" in \
+        x86_64) \
+            FDB_PACKAGE="foundationdb-clients-${FDB_VERSION}-1.el7.x86_64.rpm" && \
+            FDB_SHA256="9255a4730655ac1a8461d8da5148a9d87c8978944188477f5b745318bb6d40ba" ;; \
+        *) echo "No FoundationDB client package for ${ARCH}; skipping" && exit 0 ;; \
+    esac && \
+    yum install -y shadow-utils && \
+    echo "Installing FoundationDB client ${FDB_VERSION} for ${ARCH}..." && \
+    curl -fsSL -o /tmp/${FDB_PACKAGE} \
+        "https://github.com/apple/foundationdb/releases/download/${FDB_VERSION}/${FDB_PACKAGE}" && \
+    echo "${FDB_SHA256}  /tmp/${FDB_PACKAGE}" | sha256sum -c - && \
+    rpm -i --nodeps /tmp/${FDB_PACKAGE} && \
+    rm -f /tmp/${FDB_PACKAGE} && \
+    ldconfig && \
+    ls -l /usr/lib64/libfdb_c.so && \
+    echo "✓ FoundationDB client installed successfully for ${ARCH}"
+
 # 2. Install the Rust toolchain
 # uncomment the following two lines if you met network problem
 #ENV RUSTUP_UPDATE_ROOT=https://mirrors.aliyun.com/rustup/rustup

--- a/curvine-docker/compile/Dockerfile_centos7
+++ b/curvine-docker/compile/Dockerfile_centos7
@@ -91,6 +91,30 @@ RUN NODE_VERSION=16.20.2 && \
         tar -xJ -C /usr/local --strip-components=1 && \
     echo "✓ Node.js ${NODE_VERSION} installed successfully for ${ARCH}"
 
+# 1.2. Install FoundationDB client library (x86_64)
+# Required to link libfdb_c when building curvine-mds/curvine-server
+# (foundationdb crate, fdb-7_3). The official release ships an el7 rpm for
+# x86_64 only (no aarch64 build), which is compatible with CentOS 7's glibc
+# 2.17. SHA256-pinned for supply-chain safety (same pin as the CI workflow
+# used previously).
+RUN ARCH=$(uname -m) && \
+    FDB_VERSION=7.3.77 && \
+    case "${ARCH}" in \
+        x86_64) \
+            FDB_PACKAGE="foundationdb-clients-${FDB_VERSION}-1.el7.x86_64.rpm" && \
+            FDB_SHA256="9255a4730655ac1a8461d8da5148a9d87c8978944188477f5b745318bb6d40ba" ;; \
+        *) echo "No FoundationDB client package for ${ARCH}; skipping" && exit 0 ;; \
+    esac && \
+    echo "Installing FoundationDB client ${FDB_VERSION} for ${ARCH}..." && \
+    curl -fsSL -o /tmp/${FDB_PACKAGE} \
+        "https://github.com/apple/foundationdb/releases/download/${FDB_VERSION}/${FDB_PACKAGE}" && \
+    echo "${FDB_SHA256}  /tmp/${FDB_PACKAGE}" | sha256sum -c - && \
+    rpm -i --nodeps /tmp/${FDB_PACKAGE} && \
+    rm -f /tmp/${FDB_PACKAGE} && \
+    ldconfig && \
+    ls -l /usr/lib64/libfdb_c.so && \
+    echo "✓ FoundationDB client installed successfully for ${ARCH}"
+
 # 2. Install the Rust toolchain
 # uncomment the following two lines if you met network problem
 #ENV RUSTUP_UPDATE_ROOT=https://mirrors.aliyun.com/rustup/rustup

--- a/curvine-docker/compile/Dockerfile_rocky9
+++ b/curvine-docker/compile/Dockerfile_rocky9
@@ -62,6 +62,32 @@ RUN curl -sL https://rpm.nodesource.com/setup_22.x | bash - && \
     dnf install -y --nobest nodejs && \
     dnf clean all
 
+# 1.2. Install FoundationDB client library (multi-arch)
+# Required to link libfdb_c when building curvine-mds/curvine-server
+# (foundationdb crate, fdb-7_3). The official release ships x86_64 as el7
+# and aarch64 as el9 rpms; both are compatible with Rocky 9. SHA256-pinned
+# for supply-chain safety (same pin as the CI workflow used previously).
+RUN ARCH=$(uname -m) && \
+    FDB_VERSION=7.3.77 && \
+    case "${ARCH}" in \
+        x86_64) \
+            FDB_PACKAGE="foundationdb-clients-${FDB_VERSION}-1.el7.x86_64.rpm" && \
+            FDB_SHA256="9255a4730655ac1a8461d8da5148a9d87c8978944188477f5b745318bb6d40ba" ;; \
+        aarch64) \
+            FDB_PACKAGE="foundationdb-clients-${FDB_VERSION}-1.el9.aarch64.rpm" && \
+            FDB_SHA256="b6980a23c23c61dea08d8f665395593a7b2972fac04d0cb822d9a42c7202efa6" ;; \
+        *) echo "Unsupported architecture: ${ARCH}" && exit 1 ;; \
+    esac && \
+    echo "Installing FoundationDB client ${FDB_VERSION} for ${ARCH}..." && \
+    curl -fsSL -o /tmp/${FDB_PACKAGE} \
+        "https://github.com/apple/foundationdb/releases/download/${FDB_VERSION}/${FDB_PACKAGE}" && \
+    echo "${FDB_SHA256}  /tmp/${FDB_PACKAGE}" | sha256sum -c - && \
+    rpm -i --nodeps /tmp/${FDB_PACKAGE} && \
+    rm -f /tmp/${FDB_PACKAGE} && \
+    ldconfig && \
+    ls -l /usr/lib64/libfdb_c.so && \
+    echo "✓ FoundationDB client installed successfully for ${ARCH}"
+
 # 2. Install the Rust toolchain
 # uncomment the following two lines if you met network problem
 #ENV RUSTUP_UPDATE_ROOT=https://mirrors.aliyun.com/rustup/rustup

--- a/curvine-docker/compile/Dockerfile_rocky9_cached
+++ b/curvine-docker/compile/Dockerfile_rocky9_cached
@@ -44,6 +44,32 @@ RUN curl -sL https://rpm.nodesource.com/setup_22.x | bash - && \
     dnf install -y --nobest nodejs && \
     dnf clean all
 
+# 1.2. Install FoundationDB client library (multi-arch)
+# Required to link libfdb_c when building curvine-mds/curvine-server
+# (foundationdb crate, fdb-7_3). Official release ships x86_64 as el7 and
+# aarch64 as el9 rpms; both are compatible with Rocky 9. SHA256-pinned for
+# supply-chain safety (same pins as the CI workflow used previously).
+RUN ARCH=$(uname -m) && \
+    FDB_VERSION=7.3.77 && \
+    case "${ARCH}" in \
+        x86_64) \
+            FDB_PACKAGE="foundationdb-clients-${FDB_VERSION}-1.el7.x86_64.rpm" && \
+            FDB_SHA256="9255a4730655ac1a8461d8da5148a9d87c8978944188477f5b745318bb6d40ba" ;; \
+        aarch64) \
+            FDB_PACKAGE="foundationdb-clients-${FDB_VERSION}-1.el9.aarch64.rpm" && \
+            FDB_SHA256="b6980a23c23c61dea08d8f665395593a7b2972fac04d0cb822d9a42c7202efa6" ;; \
+        *) echo "Unsupported architecture: ${ARCH}" && exit 1 ;; \
+    esac && \
+    echo "Installing FoundationDB client ${FDB_VERSION} for ${ARCH}..." && \
+    curl -fsSL -o /tmp/${FDB_PACKAGE} \
+        "https://github.com/apple/foundationdb/releases/download/${FDB_VERSION}/${FDB_PACKAGE}" && \
+    echo "${FDB_SHA256}  /tmp/${FDB_PACKAGE}" | sha256sum -c - && \
+    rpm -i --nodeps /tmp/${FDB_PACKAGE} && \
+    rm -f /tmp/${FDB_PACKAGE} && \
+    ldconfig && \
+    ls -l /usr/lib64/libfdb_c.so && \
+    echo "✓ FoundationDB client installed successfully for ${ARCH}"
+
 # 2. Install the Rust toolchain
 # uncomment the following two lines if you met network problem
 #ENV RUSTUP_UPDATE_ROOT=https://mirrors.aliyun.com/rustup/rustup

--- a/curvine-docker/compile/Dockerfile_ubuntu22
+++ b/curvine-docker/compile/Dockerfile_ubuntu22
@@ -33,6 +33,7 @@ RUN apt-get update && apt-get install -y \
     libstdc++-12-dev \
     zlib1g-dev \
     fio \
+    adduser \
     ca-certificates \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
@@ -66,6 +67,37 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
     apt-get install -y nodejs && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+
+# 1.2. Install FoundationDB client library (multi-arch)
+# Required to link libfdb_c when building curvine-mds/curvine-server
+# (foundationdb crate, fdb-7_3). The official release ships .deb packages
+# for amd64 and arm64; SHA256-pinned for supply-chain safety (same pins as
+# the CI workflow used previously). The library installs to /usr/lib; a
+# symlink into the multiarch lib dir guarantees the linker finds it without
+# extra flags (adduser is a postinst dependency of the deb).
+RUN ARCH=$(uname -m) && \
+    FDB_VERSION=7.3.77 && \
+    case "${ARCH}" in \
+        x86_64) \
+            FDB_PACKAGE="foundationdb-clients_${FDB_VERSION}-1_amd64.deb" && \
+            FDB_SHA256="b6c263723009bddbc30b6ae8cf9854340bd35cef14152abb0da8fb5af2b91254" && \
+            MULTIARCH_DIR="x86_64-linux-gnu" ;; \
+        aarch64) \
+            FDB_PACKAGE="foundationdb-clients_${FDB_VERSION}-1_aarch64.deb" && \
+            FDB_SHA256="b3a5dd972ffd37c1d5dc0c29ffa00e2169bcac62c0186571acced8b006af7cc2" && \
+            MULTIARCH_DIR="aarch64-linux-gnu" ;; \
+        *) echo "Unsupported architecture: ${ARCH}" && exit 1 ;; \
+    esac && \
+    echo "Installing FoundationDB client ${FDB_VERSION} for ${ARCH}..." && \
+    curl -fsSL -o /tmp/${FDB_PACKAGE} \
+        "https://github.com/apple/foundationdb/releases/download/${FDB_VERSION}/${FDB_PACKAGE}" && \
+    echo "${FDB_SHA256}  /tmp/${FDB_PACKAGE}" | sha256sum -c - && \
+    dpkg -i /tmp/${FDB_PACKAGE} && \
+    rm -f /tmp/${FDB_PACKAGE} && \
+    ln -sf /usr/lib/libfdb_c.so /usr/lib/${MULTIARCH_DIR}/libfdb_c.so && \
+    ldconfig && \
+    ls -l /usr/lib/libfdb_c.so && \
+    echo "✓ FoundationDB client installed successfully for ${ARCH}"
 
 # 2. Install the Rust toolchain
 # uncomment the following two lines if you met network problem

--- a/curvine-docker/compile/Dockerfile_ubuntu24
+++ b/curvine-docker/compile/Dockerfile_ubuntu24
@@ -33,6 +33,7 @@ RUN apt-get update && apt-get install -y \
     libstdc++-13-dev \
     zlib1g-dev \
     fio \
+    adduser \
     ca-certificates \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
@@ -66,6 +67,37 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
     apt-get install -y nodejs && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+
+# 1.2. Install FoundationDB client library (multi-arch)
+# Required to link libfdb_c when building curvine-mds/curvine-server
+# (foundationdb crate, fdb-7_3). The official release ships .deb packages
+# for amd64 and arm64; SHA256-pinned for supply-chain safety (same pins as
+# the CI workflow used previously). The library installs to /usr/lib; a
+# symlink into the multiarch lib dir guarantees the linker finds it without
+# extra flags (adduser is a postinst dependency of the deb).
+RUN ARCH=$(uname -m) && \
+    FDB_VERSION=7.3.77 && \
+    case "${ARCH}" in \
+        x86_64) \
+            FDB_PACKAGE="foundationdb-clients_${FDB_VERSION}-1_amd64.deb" && \
+            FDB_SHA256="b6c263723009bddbc30b6ae8cf9854340bd35cef14152abb0da8fb5af2b91254" && \
+            MULTIARCH_DIR="x86_64-linux-gnu" ;; \
+        aarch64) \
+            FDB_PACKAGE="foundationdb-clients_${FDB_VERSION}-1_aarch64.deb" && \
+            FDB_SHA256="b3a5dd972ffd37c1d5dc0c29ffa00e2169bcac62c0186571acced8b006af7cc2" && \
+            MULTIARCH_DIR="aarch64-linux-gnu" ;; \
+        *) echo "Unsupported architecture: ${ARCH}" && exit 1 ;; \
+    esac && \
+    echo "Installing FoundationDB client ${FDB_VERSION} for ${ARCH}..." && \
+    curl -fsSL -o /tmp/${FDB_PACKAGE} \
+        "https://github.com/apple/foundationdb/releases/download/${FDB_VERSION}/${FDB_PACKAGE}" && \
+    echo "${FDB_SHA256}  /tmp/${FDB_PACKAGE}" | sha256sum -c - && \
+    dpkg -i /tmp/${FDB_PACKAGE} && \
+    rm -f /tmp/${FDB_PACKAGE} && \
+    ln -sf /usr/lib/libfdb_c.so /usr/lib/${MULTIARCH_DIR}/libfdb_c.so && \
+    ldconfig && \
+    ls -l /usr/lib/libfdb_c.so && \
+    echo "✓ FoundationDB client installed successfully for ${ARCH}"
 
 # 2. Install the Rust toolchain
 # uncomment the following two lines if you met network problem

--- a/curvine-docker/deploy/Dockerfile_rocky9
+++ b/curvine-docker/deploy/Dockerfile_rocky9
@@ -172,6 +172,11 @@ COPY --from=builder /opt/spdk/isa-l/.libs/libisal* /usr/lib64/
 COPY --from=builder /opt/spdk/isa-l-crypto/.libs/libisal* /usr/lib64/
 RUN ldconfig
 
+# Copy FoundationDB client library (curvine-server links libfdb_c for the
+# FDB KV backend; installed in the compile image's /usr/lib64)
+COPY --from=builder /usr/lib64/libfdb_c.so /usr/lib64/
+RUN ldconfig
+
 # Copy JindoSDK from builder stage for OSS-HDFS support
 COPY --from=builder /opt/jindosdk /opt/jindosdk
 

--- a/curvine-docker/deploy/Dockerfile_ubuntu24
+++ b/curvine-docker/deploy/Dockerfile_ubuntu24
@@ -41,10 +41,42 @@ RUN apt-get update && apt-get install -y --fix-missing \
     zlib1g-dev \
     pkg-config \
     ca-certificates \
+    adduser \
     fio \
     rsync \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+# 1.1. Install FoundationDB client library (multi-arch)
+# Required to link libfdb_c when building curvine-mds/curvine-server
+# (foundationdb crate, fdb-7_3). The official release ships .deb packages
+# for amd64 and arm64; SHA256-pinned for supply-chain safety (same pins as
+# the CI workflow used previously). The library installs to /usr/lib; a
+# symlink into the multiarch lib dir guarantees the linker finds it without
+# extra flags (adduser is a postinst dependency of the deb).
+RUN ARCH=$(uname -m) && \
+    FDB_VERSION=7.3.77 && \
+    case "${ARCH}" in \
+        x86_64) \
+            FDB_PACKAGE="foundationdb-clients_${FDB_VERSION}-1_amd64.deb" && \
+            FDB_SHA256="b6c263723009bddbc30b6ae8cf9854340bd35cef14152abb0da8fb5af2b91254" && \
+            MULTIARCH_DIR="x86_64-linux-gnu" ;; \
+        aarch64) \
+            FDB_PACKAGE="foundationdb-clients_${FDB_VERSION}-1_aarch64.deb" && \
+            FDB_SHA256="b3a5dd972ffd37c1d5dc0c29ffa00e2169bcac62c0186571acced8b006af7cc2" && \
+            MULTIARCH_DIR="aarch64-linux-gnu" ;; \
+        *) echo "Unsupported architecture: ${ARCH}" && exit 1 ;; \
+    esac && \
+    echo "Installing FoundationDB client ${FDB_VERSION} for ${ARCH}..." && \
+    curl -fsSL -o /tmp/${FDB_PACKAGE} \
+        "https://github.com/apple/foundationdb/releases/download/${FDB_VERSION}/${FDB_PACKAGE}" && \
+    echo "${FDB_SHA256}  /tmp/${FDB_PACKAGE}" | sha256sum -c - && \
+    dpkg -i /tmp/${FDB_PACKAGE} && \
+    rm -f /tmp/${FDB_PACKAGE} && \
+    ln -sf /usr/lib/libfdb_c.so /usr/lib/${MULTIARCH_DIR}/libfdb_c.so && \
+    ldconfig && \
+    ls -l /usr/lib/libfdb_c.so && \
+    echo "✓ FoundationDB client installed successfully for ${ARCH}"
 
 # 2. Install the Rust toolchain
 RUN export PATH="/root/.cargo/bin:${PATH}" && \
@@ -227,9 +259,21 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     zlib1g \
     libstdc++6 \
     python3 \
+    liblzma5 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /var/cache/apt/*
+
+# Copy FoundationDB client library (curvine-server links libfdb_c for the
+# FDB KV backend; installed in the builder stage's /usr/lib).
+COPY --from=builder /usr/lib/libfdb_c.so /usr/lib/
+RUN ARCH=$(uname -m) && \
+    case "${ARCH}" in \
+        x86_64) ln -sf /usr/lib/libfdb_c.so /usr/lib/x86_64-linux-gnu/libfdb_c.so ;; \
+        aarch64) ln -sf /usr/lib/libfdb_c.so /usr/lib/aarch64-linux-gnu/libfdb_c.so ;; \
+        *) echo "Unsupported architecture: ${ARCH}" && exit 1 ;; \
+    esac && \
+    ldconfig
 
 # Copy JindoSDK from builder stage for OSS-HDFS support
 COPY --from=builder /opt/jindosdk /opt/jindosdk


### PR DESCRIPTION
## Problem
curvine-server links libfdb_c for the FDB KV backend, but CI images
did not include it: build.yml downloaded the client rpm on every run
(x86_64 only), while daily-ut-coverage.yml and release.yml had no
install step at all, silently depending on an FDB client that was
missing or required per-job setup.

## Design
Bake libfdb_c into every compile image so every CI job and downstream
build (runtime image, CSI image, Java SDK, tests) gets the library for
free. The official release ships x86_64 as an el7 rpm and amd64/arm64
as .deb packages, plus an el9 aarch64 rpm for Rocky 9. Each Dockerfile
selects by `uname -m` with a SHA256 pin per architecture. build.yml
drops its per-job download step; the deploy runtime images copy
libfdb_c.so from the builder stage since the runtime needs it to start
the server with kv_backend = "fdb".

## Key Changes
- curvine-docker/compile/Dockerfile_rocky9: multi-arch FDB client install (was: el7 rpm only)
- curvine-docker/compile/Dockerfile_rocky9_cached: same, for the cached variant
- curvine-docker/compile/Dockerfile_ubuntu22: deb install (amd64 + arm64)
- curvine-docker/compile/Dockerfile_ubuntu24: deb install (amd64 + arm64)
- curvine-docker/compile/Dockerfile_amzn2: el7 rpm install (x86_64 only; no aarch64 package)
- curvine-docker/compile/Dockerfile_centos7: el7 rpm install (x86_64 only; no aarch64 package)
- curvine-docker/deploy/Dockerfile_rocky9: copy libfdb_c.so into runtime stage
- curvine-docker/deploy/Dockerfile_ubuntu24: copy libfdb_c.so into runtime stage
- .github/workflows/build.yml: remove per-job FDB rpm download step

## Note
Rebuild and republish all compile images, tests image, and deploy images
for CI to pick this up.