### PR TITLE
feat(master): add inode id to resize and assign worker RPCs (#1662)

### DIFF
--- a/crates/client/curvine-client-core/src/file/fs_client.rs
+++ b/crates/client/curvine-client-core/src/file/fs_client.rs
@@ -787,9 +787,28 @@ impl FsClient {
     }
 
     pub async fn resize(&self, path: &Path, alloc_opts: FileAllocOpts) -> FsResult<FileBlocks> {
+        self.resize0(path, None, alloc_opts).await
+    }
+
+    pub async fn resize_by_id(
+        &self,
+        path: &Path,
+        inode_id: i64,
+        alloc_opts: FileAllocOpts,
+    ) -> FsResult<FileBlocks> {
+        self.resize0(path, Some(inode_id), alloc_opts).await
+    }
+
+    async fn resize0(
+        &self,
+        path: &Path,
+        inode_id: Option<i64>,
+        alloc_opts: FileAllocOpts,
+    ) -> FsResult<FileBlocks> {
         let req = FileResizeRequest {
             path: path.encode(),
             opts: ProtoUtils::file_alloc_opts_to_pb(alloc_opts),
+            inode_id,
         };
 
         let rep: FileResizeResponse = self.rpc(RpcCode::ResizeFile, req).await?;
@@ -797,11 +816,30 @@ impl FsClient {
     }
 
     pub async fn assign_worker(&self, path: &Path, block: ExtendedBlock) -> FsResult<LocatedBlock> {
+        self.assign_worker0(path, None, block).await
+    }
+
+    pub async fn assign_worker_by_id(
+        &self,
+        path: &Path,
+        inode_id: i64,
+        block: ExtendedBlock,
+    ) -> FsResult<LocatedBlock> {
+        self.assign_worker0(path, Some(inode_id), block).await
+    }
+
+    async fn assign_worker0(
+        &self,
+        path: &Path,
+        inode_id: Option<i64>,
+        block: ExtendedBlock,
+    ) -> FsResult<LocatedBlock> {
         let req = AssignWorkerRequest {
             path: path.encode(),
             block: ProtoUtils::extend_block_to_pb(block),
             exclude_workers: self.context.exclude_workers(),
             client_address: self.context.client_addr_pb(),
+            inode_id,
         };
 
         let rep: AssignWorkerResponse = self.rpc(RpcCode::AssignWorker, req).await?;

--- a/crates/client/curvine-client-core/src/file/fs_writer_base.rs
+++ b/crates/client/curvine-client-core/src/file/fs_writer_base.rs
@@ -385,7 +385,11 @@ impl FsWriterBase {
                                 let lb = if lb.should_assign() {
                                     let assign_lb = self
                                         .fs_client
-                                        .assign_worker(&self.path, lb.block.clone())
+                                        .assign_worker_by_id(
+                                            &self.path,
+                                            self.file_blocks.status.id,
+                                            lb.block.clone(),
+                                        )
                                         .await?;
 
                                     self.file_blocks.update_locate(&assign_lb)?;
@@ -520,11 +524,14 @@ impl FsWriterBase {
         // writes; forcing complete() whenever len > 0 can surface EIO from a
         // redundant metadata complete on an already-consistent file.
         if self.has_pending_blocks() {
-            self.complete().await?;
+            self.flush().await?;
         }
 
         // Step 2: Execute resize operation
-        let file_blocks = self.fs_client.resize(&self.path, opts).await?;
+        let file_blocks = self
+            .fs_client
+            .resize_by_id(&self.path, self.file_blocks.status.id, opts)
+            .await?;
         let mut file_blocks = WriteFileBlocks::new(file_blocks);
         let block_size = file_blocks.status.block_size;
         if file_blocks.len() != len {

--- a/crates/common/curvine-proto/proto/master.proto
+++ b/crates/common/curvine-proto/proto/master.proto
@@ -314,6 +314,7 @@ message MetricsReportResponse {
 message FileResizeRequest {
     required string path = 1;
     required FileAllocOptsProto opts = 2;
+    optional int64 inode_id = 3;
 }
 
 message FileResizeResponse {
@@ -325,6 +326,7 @@ message AssignWorkerRequest {
     required ExtendedBlockProto block = 2;
     repeated uint32 exclude_workers = 3;
     required ClientAddressProto client_address = 4;
+    optional int64 inode_id = 5;
 }
 
 message AssignWorkerResponse {

--- a/curvine-master/src/master/fs/master_filesystem.rs
+++ b/curvine-master/src/master/fs/master_filesystem.rs
@@ -1679,8 +1679,9 @@ impl MasterFilesystem {
         } else {
             self.worker_manager.read().available_bytes()
         };
+
+        let mut fs_dir = self.fs_dir.write();
         let (del_res, inode) = {
-            let mut fs_dir = self.fs_dir.write();
             let mut inode = Self::resolve_file_inode(&fs_dir, path, inode_id)?;
             let file = inode.as_file_ref()?;
             Self::validate_alloc_capacity(file.len, file.replicas, &opts, available)?;
@@ -1693,7 +1694,6 @@ impl MasterFilesystem {
         }
 
         let blocks = {
-            let fs_dir = self.fs_dir.read();
             let file = inode.as_file_ref()?;
             let locs = self.get_block_locs(path, &fs_dir, file)?;
             let status = inode.to_file_status(path)?;

--- a/curvine-master/src/master/fs/master_filesystem.rs
+++ b/curvine-master/src/master/fs/master_filesystem.rs
@@ -1659,6 +1659,15 @@ impl MasterFilesystem {
     }
 
     pub fn resize<T: AsRef<str>>(&self, path: T, opts: FileAllocOpts) -> FsResult<FileBlocks> {
+        self.resize_by_id(path, None, opts)
+    }
+
+    pub fn resize_by_id<T: AsRef<str>>(
+        &self,
+        path: T,
+        inode_id: Option<i64>,
+        opts: FileAllocOpts,
+    ) -> FsResult<FileBlocks> {
         opts.validate()?;
 
         let path = path.as_ref();
@@ -1670,30 +1679,26 @@ impl MasterFilesystem {
         } else {
             self.worker_manager.read().available_bytes()
         };
-        let (del_res, inode_id) = {
+        let (del_res, inode) = {
             let mut fs_dir = self.fs_dir.write();
-            let inp = Self::resolve_path(&fs_dir, path)?;
-            let inode = try_option!(inp.get_last_inode(), "File {} not exists", path);
+            let mut inode = Self::resolve_file_inode(&fs_dir, path, inode_id)?;
             let file = inode.as_file_ref()?;
             Self::validate_alloc_capacity(file.len, file.replicas, &opts, available)?;
-            let inode_id = inode.id();
-            let del_res = fs_dir.resize(&inp, opts)?;
-            (del_res, inode_id)
+            let del_res = fs_dir.resize_inode(path, &mut inode, opts)?;
+            (del_res, inode)
         };
 
         if !del_res.blocks.is_empty() {
             self.worker_manager.write().remove_blocks(&del_res);
         }
 
-        let blocks = self.get_block_locations(path)?;
-        if blocks.status.id != inode_id {
-            return err_box!(
-                "Path {} resolved to different inode after resize, expected {}, got {}",
-                path,
-                inode_id,
-                blocks.status.id
-            );
-        }
+        let blocks = {
+            let fs_dir = self.fs_dir.read();
+            let file = inode.as_file_ref()?;
+            let locs = self.get_block_locs(path, &fs_dir, file)?;
+            let status = inode.to_file_status(path)?;
+            FileBlocks::new(status, locs)
+        };
 
         Ok(blocks)
     }
@@ -1705,16 +1710,28 @@ impl MasterFilesystem {
         client_addr: ClientAddress,
         exclude_workers: Vec<u32>,
     ) -> FsResult<LocatedBlock> {
+        self.assign_worker_by_id(path, None, block, client_addr, exclude_workers)
+    }
+
+    pub fn assign_worker_by_id<T: AsRef<str>>(
+        &self,
+        path: T,
+        inode_id: Option<i64>,
+        block: ExtendedBlock,
+        client_addr: ClientAddress,
+        exclude_workers: Vec<u32>,
+    ) -> FsResult<LocatedBlock> {
         let path = path.as_ref();
         let mut fs_dir = self.fs_dir.write();
-        let inp = Self::resolve_path(&fs_dir, path)?;
+        let mut inode = Self::resolve_file_inode(&fs_dir, path, inode_id)?;
 
-        let choose_workers = self.choose_worker(&inp, client_addr, exclude_workers)?;
+        let choose_workers =
+            self.choose_worker_for_file(inode.as_file_ref()?, client_addr, exclude_workers)?;
         let has_spdk = {
             let wm = self.worker_manager.read();
             wm.workers_have_spdk(&choose_workers)
         };
-        let block = fs_dir.assign_worker(inp, block.id, &choose_workers)?;
+        let block = fs_dir.assign_worker_inode(path, &mut inode, block.id, &choose_workers)?;
 
         Ok(LocatedBlock {
             block,

--- a/curvine-master/src/master/master_handler.rs
+++ b/curvine-master/src/master/master_handler.rs
@@ -917,8 +917,9 @@ impl MasterHandler {
         let header: FileResizeRequest = ctx.parse_header()?;
         ctx.set_audit(Some(header.path.to_string()), None);
 
-        let file_blocks = self.fs.resize(
+        let file_blocks = self.fs.resize_by_id(
             &header.path,
+            header.inode_id,
             ProtoUtils::file_alloc_opts_from_pb(header.opts),
         )?;
         let rep_header = FileResizeResponse {
@@ -931,8 +932,9 @@ impl MasterHandler {
         let header: AssignWorkerRequest = ctx.parse_header()?;
         ctx.set_audit(Some(header.path.to_string()), None);
 
-        let block = self.fs.assign_worker(
+        let block = self.fs.assign_worker_by_id(
             &header.path,
+            header.inode_id,
             ProtoUtils::extend_block_from_pb(header.block),
             ProtoUtils::client_address_from_pb(header.client_address),
             header.exclude_workers,

--- a/curvine-master/src/master/meta/fs_dir.rs
+++ b/curvine-master/src/master/meta/fs_dir.rs
@@ -1312,13 +1312,22 @@ impl FsDir {
             Some(v) => v,
             None => return err_ext!(FsError::file_not_found(inp.path())),
         };
+        self.resize_inode(inp.path(), &mut inode, opts)
+    }
+
+    pub fn resize_inode(
+        &mut self,
+        audit_path: &str,
+        inode: &mut InodePtr,
+        opts: FileAllocOpts,
+    ) -> FsResult<DeleteResult> {
         let file = inode.as_file_mut()?;
 
         if file.len == opts.len {
             return Ok(DeleteResult::new());
         }
         let del_blocks = file.resize(opts.clone())?;
-        debug!("resize file {} success, opts: {:?}", inp.path(), opts);
+        debug!("resize file {} success, opts: {:?}", audit_path, opts);
 
         file.complete(file.len, &[], "", true)?;
         let mut del_res = DeleteResult::new();
@@ -1331,7 +1340,7 @@ impl FsDir {
 
         self.store.apply_complete_file(inode.as_ref(), &[])?;
         self.journal_writer
-            .log_complete_file(self, inp.path(), inode.as_file_ref()?, vec![])?;
+            .log_complete_file(self, audit_path, inode.as_file_ref()?, vec![])?;
 
         Ok(del_res)
     }
@@ -1343,6 +1352,16 @@ impl FsDir {
         workers: &[WorkerAddress],
     ) -> FsResult<ExtendedBlock> {
         let mut inode = try_option!(inp.get_last_inode(), "File {} not exists", inp.path());
+        self.assign_worker_inode(inp.path(), &mut inode, block_id, workers)
+    }
+
+    pub fn assign_worker_inode(
+        &mut self,
+        audit_path: &str,
+        inode: &mut InodePtr,
+        block_id: i64,
+        workers: &[WorkerAddress],
+    ) -> FsResult<ExtendedBlock> {
         let file = inode.as_file_mut()?;
 
         let block = file.search_block_mut_check(block_id)?;
@@ -1358,7 +1377,7 @@ impl FsDir {
         if res {
             self.store.apply_new_block(inode.as_ref(), &[])?;
             self.journal_writer
-                .log_add_block(self, inp.path(), inode.as_file_ref()?, vec![])?;
+                .log_add_block(self, audit_path, inode.as_file_ref()?, vec![])?;
         }
 
         Ok(block)

--- a/curvine-tests/tests/fs_test.rs
+++ b/curvine-tests/tests/fs_test.rs
@@ -225,6 +225,9 @@ fn run_filesystem_end_to_end_operations_on_cluster(
         open_file_rename_read_write(&fs).await?;
         println!("open_file_rename_read_write done");
 
+        open_file_rename_sparse_write(&fs).await?;
+        println!("open_file_rename_sparse_write done");
+
         set_attr_non_recursive(&fs).await?;
         println!("set_attr_non_recursive done");
 
@@ -583,6 +586,50 @@ async fn open_file_rename_read_write(fs: &CurvineFileSystem) -> CommonResult<()>
     buffer.truncate(bytes_read);
     assert_eq!(String::from_utf8(buffer.to_vec())?, "read-before-rename");
     assert_eq!(fs.read_string(&read_dst).await?, "read-before-rename");
+
+    Ok(())
+}
+
+/// Regression: an open writer retains its original path, while rename moves
+/// the directory entry. A later seek-past-EOF write invokes ResizeFile (and may
+/// assign a sparse block), so those operations must resolve the file by inode
+/// ID instead of the now-stale open-time path.
+async fn open_file_rename_sparse_write(fs: &CurvineFileSystem) -> CommonResult<()> {
+    let src = Path::from_str("/fs_test/open_rename_sparse/temp_shuffle")?;
+    let dst = Path::from_str("/fs_test/open_rename_sparse/shuffle_1_1_0.data")?;
+    let mut writer = fs.create(&src, true).await?;
+
+    fs.rename(&src, &dst).await?;
+    assert!(!fs.exists(&src).await?);
+    assert!(fs.exists(&dst).await?);
+
+    const HOLE_END: i64 = 4096;
+    const PREFIX: &[u8] = b"prefix";
+    const SUFFIX: &[u8] = b"suffix";
+
+    // Flushing this buffered write during the following seek triggers the
+    // rename-sensitive sparse resize and block assignment paths.
+    writer.seek(HOLE_END).await?;
+    writer.write(SUFFIX).await?;
+    writer.seek(0).await?;
+    writer.write(PREFIX).await?;
+    writer.complete().await?;
+
+    let expected_len = HOLE_END as usize + SUFFIX.len();
+    let status = fs.get_status(&dst).await?;
+    assert_eq!(status.len, expected_len as i64);
+
+    let mut reader = fs.open(&dst).await?;
+    let mut actual = vec![0u8; expected_len];
+    let read = reader.read_full(&mut actual).await?;
+    reader.complete().await?;
+
+    assert_eq!(read, expected_len);
+    assert_eq!(&actual[..PREFIX.len()], PREFIX);
+    assert!(actual[PREFIX.len()..HOLE_END as usize]
+        .iter()
+        .all(|&byte| byte == 0));
+    assert_eq!(&actual[HOLE_END as usize..], SUFFIX);
 
     Ok(())
 }

--- a/curvine-tests/tests/fs_test.rs
+++ b/curvine-tests/tests/fs_test.rs
@@ -607,8 +607,8 @@ async fn open_file_rename_sparse_write(fs: &CurvineFileSystem) -> CommonResult<(
     const PREFIX: &[u8] = b"prefix";
     const SUFFIX: &[u8] = b"suffix";
 
-    // Flushing this buffered write during the following seek triggers the
-    // rename-sensitive sparse resize and block assignment paths.
+    // The write below lands at an offset past EOF, so FsWriterBase::write
+    // triggers the rename-sensitive sparse resize and block assignment paths.
     writer.seek(HOLE_END).await?;
     writer.write(SUFFIX).await?;
     writer.seek(0).await?;


### PR DESCRIPTION
# Summary

Pass the client-known inode id in resize and assign-worker requests so the master can resolve the file by inode instead of path lookup, avoiding rename/move races and redundant namespace traversal on hot write paths.

# Issue Describe / Design

Closes #1662

Design decisions and trade-offs:

- `FileResizeRequest` and `AssignWorkerRequest` gain an optional `inode_id` field (proto2 optional, backward compatible).
- The master resolves the file by inode id when provided, with path lookup as fallback (`resolve_file_inode`), so older clients keep working.
- `FsDir::resize_inode` / `FsDir::assign_worker_inode` take an already-resolved `InodePtr`; journal and audit logging still use the path string, so journal format and audit semantics are unchanged.
- The client writer already holds the file inode id in `file_blocks.status.id`, so it calls `resize_by_id` / `assign_worker_by_id` directly.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `crates/common/curvine-proto/proto/master.proto` | Add optional `inode_id` to `FileResizeRequest` (=3) and `AssignWorkerRequest` (=5) | None, optional field |
| `curvine-master/src/master/meta/fs_dir.rs` | Extract `resize_inode` / `assign_worker_inode` operating on a resolved `InodePtr` | None, original path-based methods delegate |
| `curvine-master/src/master/fs/master_filesystem.rs` | Add `resize_by_id` / `assign_worker_by_id` with inode-based resolution and path fallback; return blocks from the same resolved inode | None when `inode_id` is absent |
| `curvine-master/src/master/master_handler.rs` | Forward `inode_id` from RPC requests | None |
| `crates/client/curvine-client-core/src/file/fs_client.rs` | Add `resize_by_id` / `assign_worker_by_id`; requests carry `inode_id` | None |
| `crates/client/curvine-client-core/src/file/fs_writer_base.rs` | Writer passes `file_blocks.status.id` on resize / assign-worker; flush instead of full complete before resize | Assign/resize now resolve by inode id |
| `curvine-tests/tests/fs_test.rs` | Add resize-by-inode-id coverage | None |

Review updates:

- `resize_by_id` now holds the `fs_dir` write guard across the whole flow (resolve, resize, `remove_blocks`, response build), so concurrent `complete_file` / `add_block` / second resize can no longer be omitted from the returned `FileBlocks`; the legacy (`inode_id == None`) path is also protected against delete/recreate races, since resolution and response build are atomic under one write lock.
- Corrected the regression test comment to describe the actual resize trigger (write at an offset past EOF).

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test -p curvine-tests --test fs_test` | Passed | Includes the new `open_file_rename_sparse_write` regression |
| Existing resize / assign-worker regression | Passed | Backward-compatible path (no `inode_id`) covered by regression suite |

# Dependencies

- Related PRs: None
- Related issues: #1662
- Blocks / blocked by: None