### PR TITLE
docs: fix broken regression README link (#1669)

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,6 +1,6 @@
 # Scripts
 
-Test-related scripts (build-server, regression, dailytest, Portal) have been moved to **curvine-tests/regression**. See [curvine-tests/README-regression.md](../curvine-tests/README-regression.md) for how to run the regression test server locally or via Docker.
+Test-related scripts (build-server, regression, dailytest, Portal) have been moved to **curvine-tests/regression**. See [curvine-tests/README.md](../curvine-tests/README.md) for how to run the regression test server locally or via Docker.
 
 This directory may still contain other non-test scripts (e.g. perf).
 


### PR DESCRIPTION
## Summary

Fix the broken link in `scripts/README.md` so it points to
`curvine-tests/README.md`.

## Validation

- Confirmed `curvine-tests/README.md` exists
- Ran `git diff --check`
- Documentation-only change; runtime tests not run

Closes #1669 