### PR TITLE
feat(java-sdk): support per-job load replicas

### DIFF
--- a/crates/common/curvine-model/src/transfer.rs
+++ b/crates/common/curvine-model/src/transfer.rs
@@ -157,6 +157,7 @@ pub struct TransferCommand {
 
 impl TransferCommand {
     pub const OVERWRITE_OPTION: &'static str = "overwrite";
+    pub const REPLICAS_OPTION: &'static str = "replicas";
 
     pub fn job_key(&self) -> String {
         format!("{:?}:{}:{}", self.kind, self.source_path, self.target_path)
@@ -196,6 +197,34 @@ impl TransferCommand {
         )
     }
 
+    pub fn default_client_request_id_with_overwrite_and_replicas(
+        kind: TransferKind,
+        source_path: impl AsRef<str>,
+        target_path: impl AsRef<str>,
+        overwrite: bool,
+        replicas: Option<i32>,
+    ) -> String {
+        let Some(replicas) = replicas else {
+            return Self::default_client_request_id_with_overwrite(
+                kind,
+                source_path,
+                target_path,
+                overwrite,
+            );
+        };
+        format!(
+            "job_{}",
+            Utils::md5(format!(
+                "{:?}:{}:{}:overwrite={}:replicas={}",
+                kind,
+                source_path.as_ref(),
+                target_path.as_ref(),
+                overwrite,
+                replicas
+            ))
+        )
+    }
+
     pub fn overwrite(&self) -> bool {
         self.options
             .get(Self::OVERWRITE_OPTION)
@@ -206,6 +235,17 @@ impl TransferCommand {
     pub fn set_overwrite(&mut self, overwrite: bool) {
         self.options
             .insert(Self::OVERWRITE_OPTION.to_string(), overwrite.to_string());
+    }
+
+    pub fn replicas(&self) -> Option<i32> {
+        self.options
+            .get(Self::REPLICAS_OPTION)
+            .and_then(|value| value.parse::<i32>().ok())
+    }
+
+    pub fn set_replicas(&mut self, replicas: i32) {
+        self.options
+            .insert(Self::REPLICAS_OPTION.to_string(), replicas.to_string());
     }
 }
 

--- a/crates/common/curvine-model/src/transfer.rs
+++ b/crates/common/curvine-model/src/transfer.rs
@@ -241,6 +241,7 @@ impl TransferCommand {
         self.options
             .get(Self::REPLICAS_OPTION)
             .and_then(|value| value.parse::<i32>().ok())
+            .filter(|replicas| *replicas > 0)
     }
 
     pub fn set_replicas(&mut self, replicas: i32) {

--- a/crates/common/curvine-model/tests/transfer_command_test.rs
+++ b/crates/common/curvine-model/tests/transfer_command_test.rs
@@ -47,3 +47,17 @@ fn replicas_change_only_explicit_load_request_ids() {
     assert_eq!(unspecified, legacy);
     assert_ne!(replicas_one, replicas_three);
 }
+
+#[test]
+fn replicas_ignore_non_positive_values() {
+    let mut command = TransferCommand::default();
+
+    command.set_replicas(0);
+    assert_eq!(command.replicas(), None);
+
+    command.set_replicas(-1);
+    assert_eq!(command.replicas(), None);
+
+    command.set_replicas(3);
+    assert_eq!(command.replicas(), Some(3));
+}

--- a/crates/common/curvine-model/tests/transfer_command_test.rs
+++ b/crates/common/curvine-model/tests/transfer_command_test.rs
@@ -1,0 +1,49 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use curvine_model::{TransferCommand, TransferKind};
+
+#[test]
+fn replicas_change_only_explicit_load_request_ids() {
+    let legacy = TransferCommand::default_client_request_id_with_overwrite(
+        TransferKind::Load,
+        "s3://bucket/source",
+        "/target",
+        true,
+    );
+    let unspecified = TransferCommand::default_client_request_id_with_overwrite_and_replicas(
+        TransferKind::Load,
+        "s3://bucket/source",
+        "/target",
+        true,
+        None,
+    );
+    let replicas_one = TransferCommand::default_client_request_id_with_overwrite_and_replicas(
+        TransferKind::Load,
+        "s3://bucket/source",
+        "/target",
+        true,
+        Some(1),
+    );
+    let replicas_three = TransferCommand::default_client_request_id_with_overwrite_and_replicas(
+        TransferKind::Load,
+        "s3://bucket/source",
+        "/target",
+        true,
+        Some(3),
+    );
+
+    assert_eq!(unspecified, legacy);
+    assert_ne!(replicas_one, replicas_three);
+}

--- a/crates/sdk/curvine-libsdk-java/src/java/java_abi.rs
+++ b/crates/sdk/curvine-libsdk-java/src/java/java_abi.rs
@@ -362,7 +362,30 @@ pub unsafe extern "C" fn Java_io_curvine_CurvineNative_submitLoadJob(
     let fs = &*fs_ptr;
     java_err2!(
         env,
-        fs.submit_load_job(&mut env, source_path, target_path, overwrite)
+        fs.submit_load_job(&mut env, source_path, target_path, overwrite, None)
+    )
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn Java_io_curvine_CurvineNative_submitLoadJobWithReplicas(
+    mut env: JNIEnv,
+    _this: JObject,
+    fs_ptr: *mut JavaFilesystem,
+    source_path: JString,
+    target_path: JString,
+    overwrite: jboolean,
+    replicas: jint,
+) -> jarray {
+    let fs = &*fs_ptr;
+    java_err2!(
+        env,
+        fs.submit_load_job(
+            &mut env,
+            source_path,
+            target_path,
+            overwrite,
+            Some(replicas),
+        )
     )
 }
 

--- a/crates/sdk/curvine-libsdk-java/src/java/java_filesystem.rs
+++ b/crates/sdk/curvine-libsdk-java/src/java/java_filesystem.rs
@@ -24,7 +24,7 @@ use curvine_fs_api::state::{DeleteResult, LoadJobCommand, SetAttrOpts};
 use curvine_fs_api::utils::ProtoUtils;
 use curvine_sdk_core::blocking_job as job;
 use jni::objects::{JByteArray, JString};
-use jni::sys::{jarray, jboolean, jstring};
+use jni::sys::{jarray, jboolean, jint, jstring};
 use jni::JNIEnv;
 use prost::Message;
 
@@ -53,6 +53,7 @@ fn decode_load_job_command(
     source_path: JString,
     target_path: JString,
     overwrite: jboolean,
+    replicas: Option<jint>,
 ) -> FsResult<LoadJobCommand> {
     let source = JavaUtils::jstring_to_string(env, &source_path)?;
     let target = if target_path.is_null() {
@@ -70,6 +71,12 @@ fn decode_load_job_command(
         LoadJobCommand::builder(source).overwrite(JavaUtils::jbool_to_bool(overwrite));
     if let Some(target) = target {
         builder = builder.target_path(target);
+    }
+    if let Some(replicas) = replicas {
+        if replicas <= 0 {
+            return err_box!("load replicas must be greater than zero");
+        }
+        builder = builder.replicas(replicas);
     }
     Ok(builder.build())
 }
@@ -242,8 +249,9 @@ impl JavaFilesystem {
         source_path: JString,
         target_path: JString,
         overwrite: jboolean,
+        replicas: Option<jint>,
     ) -> FsResult<jarray> {
-        let command = decode_load_job_command(env, source_path, target_path, overwrite)?;
+        let command = decode_load_job_command(env, source_path, target_path, overwrite, replicas)?;
         let result = job::submit_load_job(self.inner.session(), command)?;
         let response = SubmitJobResponse {
             job_id: result.job_id,

--- a/crates/sdk/curvine-sdk-core/src/core/transfer_compat.rs
+++ b/crates/sdk/curvine-sdk-core/src/core/transfer_compat.rs
@@ -48,16 +48,24 @@ pub(crate) fn map_transfer_state(state: TransferState) -> JobTaskState {
     }
 }
 
-pub(crate) fn validate_transfer_command(command: &LoadJobCommand) -> FsResult<()> {
-    if command.replicas.is_some()
-        || command.block_size.is_some()
+pub(crate) fn validate_transfer_command(
+    command: &LoadJobCommand,
+    kind: TransferKind,
+) -> FsResult<()> {
+    if let Some(replicas) = command.replicas {
+        if kind != TransferKind::Load {
+            return err_box!("export does not support replicas");
+        }
+        if replicas <= 0 {
+            return err_box!("load replicas must be greater than zero");
+        }
+    }
+    if command.block_size.is_some()
         || command.storage_type.is_some()
         || command.ttl_ms.is_some()
         || command.ttl_action.is_some()
     {
-        return err_box!(
-            "transfer path does not support replicas/block_size/storage_type/ttl options"
-        );
+        return err_box!("transfer path does not support block_size/storage_type/ttl options");
     }
     Ok(())
 }
@@ -138,22 +146,27 @@ fn build_transfer_command(
     source_path: String,
     target_path: String,
     overwrite: bool,
+    replicas: Option<i32>,
 ) -> TransferCommand {
     let mut command = TransferCommand {
         kind,
         source_path: source_path.clone(),
         target_path: target_path.clone(),
-        client_request_id: TransferCommand::default_client_request_id_with_overwrite(
+        client_request_id: TransferCommand::default_client_request_id_with_overwrite_and_replicas(
             kind,
             &source_path,
             &target_path,
             overwrite,
+            replicas,
         ),
         submitter: SUBMITTER.to_string(),
         tenant: String::new(),
         options: Default::default(),
     };
     command.set_overwrite(overwrite);
+    if let Some(replicas) = replicas {
+        command.set_replicas(replicas);
+    }
     command
 }
 
@@ -171,7 +184,7 @@ pub(crate) async fn submit_load_job(
             .await;
     }
 
-    validate_transfer_command(&command)?;
+    validate_transfer_command(&command, TransferKind::Load)?;
     let overwrite = command.overwrite.unwrap_or(true);
     let (source_path, target_path) =
         resolve_transfer_paths(session.unified(), &command, TransferKind::Load).await?;
@@ -180,6 +193,7 @@ pub(crate) async fn submit_load_job(
         source_path,
         target_path.clone(),
         overwrite,
+        command.replicas,
     );
     let response = transfer_client(session)?.submit(transfer_command).await?;
     Ok(load_job_result_from_submit(&response, target_path))
@@ -195,7 +209,7 @@ pub(crate) async fn submit_export_job(
             .await;
     }
 
-    validate_transfer_command(&command)?;
+    validate_transfer_command(&command, TransferKind::Export)?;
     if command.target_path.is_some() {
         return err_box!("export does not support an explicit target path");
     }
@@ -207,6 +221,7 @@ pub(crate) async fn submit_export_job(
         source_path,
         target_path.clone(),
         overwrite,
+        None,
     );
     let response = transfer_client(session)?.submit(transfer_command).await?;
     Ok(load_job_result_from_submit(&response, target_path))
@@ -366,36 +381,38 @@ mod tests {
     }
 
     #[test]
-    fn rejects_unsupported_transfer_load_options() {
+    fn allows_replicas_and_rejects_unsupported_transfer_load_options() {
         let command = LoadJobCommand::builder("s3://bucket/a").replicas(2).build();
-        let err = validate_transfer_command(&command).unwrap_err();
-        assert!(err.to_string().contains("does not support"));
-        assert!(!err.to_string().contains("target_path"));
+        assert!(validate_transfer_command(&command, TransferKind::Load).is_ok());
+
+        let command = LoadJobCommand::builder("s3://bucket/a").replicas(0).build();
+        let err = validate_transfer_command(&command, TransferKind::Load).unwrap_err();
+        assert!(err.to_string().contains("greater than zero"));
 
         let command = LoadJobCommand::builder("s3://bucket/a")
             .block_size(1024)
             .build();
-        assert!(validate_transfer_command(&command).is_err());
+        assert!(validate_transfer_command(&command, TransferKind::Load).is_err());
 
         let command = LoadJobCommand::builder("s3://bucket/a")
             .storage_type(StorageType::Disk)
             .build();
-        assert!(validate_transfer_command(&command).is_err());
+        assert!(validate_transfer_command(&command, TransferKind::Load).is_err());
 
         let command = LoadJobCommand::builder("s3://bucket/a")
             .ttl_ms(1000)
             .ttl_action(TtlAction::Delete)
             .build();
-        assert!(validate_transfer_command(&command).is_err());
+        assert!(validate_transfer_command(&command, TransferKind::Load).is_err());
 
         let command = LoadJobCommand::builder("s3://bucket/a")
             .target_path("/mnt/a")
             .overwrite(false)
             .build();
-        assert!(validate_transfer_command(&command).is_ok());
+        assert!(validate_transfer_command(&command, TransferKind::Load).is_ok());
 
         let command = LoadJobCommand::builder("/mnt/a").build();
-        assert!(validate_transfer_command(&command).is_ok());
+        assert!(validate_transfer_command(&command, TransferKind::Load).is_ok());
     }
 
     #[test]

--- a/crates/server/curvine-data-transfer/src/transfer/planner.rs
+++ b/crates/server/curvine-data-transfer/src/transfer/planner.rs
@@ -348,14 +348,20 @@ pub(crate) fn load_job_info(
     mount: &MountInfo,
     client_conf: &ClientConf,
 ) -> LoadJobInfo {
-    let overwrite = transfer_command(job)
+    let command = transfer_command(job).ok();
+    let overwrite = command
+        .as_ref()
         .map(|command| command.overwrite())
         .unwrap_or(true);
     LoadJobInfo {
         job_id: job.job_id.clone(),
         source_path: job.source_path.clone(),
         target_path: job.target_path.clone(),
-        replicas: mount.replicas.unwrap_or(client_conf.replicas),
+        replicas: command
+            .as_ref()
+            .and_then(|command| command.replicas())
+            .or(mount.replicas)
+            .unwrap_or(client_conf.replicas),
         block_size: mount.block_size.unwrap_or(client_conf.block_size),
         storage_type: mount.storage_type.unwrap_or(client_conf.storage_type),
         ttl_ms: mount.ttl_ms,

--- a/crates/server/curvine-data-transfer/src/transfer/service.rs
+++ b/crates/server/curvine-data-transfer/src/transfer/service.rs
@@ -198,6 +198,7 @@ where
                 )));
             }
         }
+        validate_transfer_options(&command)?;
         validate_transfer_paths(command.kind, &command.source_path, &command.target_path)?;
         command.target_path = normalized_transfer_path(&Path::from_str(&command.target_path)?);
         let snapshot = self.transfer_snapshot(&command)?;
@@ -752,6 +753,26 @@ fn transfer_kind(kind: i32) -> FsResult<TransferKind> {
         Some(TransferKindProto::TransferExport) => Ok(TransferKind::Export),
         None => Err(FsError::common(format!("Invalid transfer kind {}", kind))),
     }
+}
+
+fn validate_transfer_options(command: &TransferCommand) -> FsResult<()> {
+    let Some(value) = command.options.get(TransferCommand::REPLICAS_OPTION) else {
+        return Ok(());
+    };
+    if command.kind != TransferKind::Load {
+        return Err(FsError::common(
+            "replicas is supported only for load transfers",
+        ));
+    }
+    let replicas = value
+        .parse::<i32>()
+        .map_err(|_| FsError::common("transfer replicas must be a positive integer"))?;
+    if replicas <= 0 {
+        return Err(FsError::common(
+            "transfer replicas must be a positive integer",
+        ));
+    }
+    Ok(())
 }
 
 fn transfer_state(state: i32) -> FsResult<TransferState> {

--- a/crates/server/curvine-data-transfer/src/transfer/tests/planner_test.rs
+++ b/crates/server/curvine-data-transfer/src/transfer/tests/planner_test.rs
@@ -12,9 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use curvine_model::{FileStatus, StoragePolicy, StorageState};
+use curvine_config::ClientConf;
+use curvine_model::{
+    FileStatus, MountInfo, StoragePolicy, StorageState, TransferCommand, TransferJobRecord,
+    TransferKind, TransferProgress, TransferState,
+};
 
-use super::planner::{needs_source_status_refresh, unchanged_load_target};
+use super::planner::{load_job_info, needs_source_status_refresh, unchanged_load_target};
 
 fn source_status(mtime: i64, len: i64) -> FileStatus {
     FileStatus {
@@ -78,4 +82,47 @@ fn equal_size_timestamp_mismatch_refreshes_source_status_before_planning() {
         &source_status(11, 2048),
         Some(&target)
     ));
+}
+
+#[test]
+fn load_replicas_override_mount_and_service_defaults() {
+    let mut command = TransferCommand {
+        kind: TransferKind::Load,
+        source_path: "s3://bucket/source".to_string(),
+        target_path: "/target".to_string(),
+        ..Default::default()
+    };
+    command.set_replicas(3);
+    let job = TransferJobRecord {
+        job_key: command.job_key(),
+        job_id: "job-1".to_string(),
+        run_id: 1,
+        kind: TransferKind::Load,
+        source_path: command.source_path.clone(),
+        target_path: command.target_path.clone(),
+        command_json: serde_json::to_string(&command).unwrap(),
+        mount_snapshot_json: "{}".to_string(),
+        secret_ref_json: "{}".to_string(),
+        cluster_snapshot_version: 0,
+        cv_metadata_epoch: None,
+        state: TransferState::Pending,
+        owner: String::new(),
+        lease_epoch: 0,
+        lease_expire_at: 0,
+        cancel_requested: false,
+        summary: TransferProgress::default(),
+        client_request_id: "request-1".to_string(),
+        submitter: "test".to_string(),
+        tenant: String::new(),
+        created_at: 0,
+        updated_at: 0,
+    };
+    let mount = MountInfo {
+        replicas: Some(2),
+        ..Default::default()
+    };
+    let mut client_conf = ClientConf::default();
+    client_conf.replicas = 1;
+
+    assert_eq!(load_job_info(&job, &mount, &client_conf).replicas, 3);
 }

--- a/crates/server/curvine-data-transfer/src/transfer/tests/planner_test.rs
+++ b/crates/server/curvine-data-transfer/src/transfer/tests/planner_test.rs
@@ -121,8 +121,10 @@ fn load_replicas_override_mount_and_service_defaults() {
         replicas: Some(2),
         ..Default::default()
     };
-    let mut client_conf = ClientConf::default();
-    client_conf.replicas = 1;
+    let client_conf = ClientConf {
+        replicas: 1,
+        ..Default::default()
+    };
 
     assert_eq!(load_job_info(&job, &mount, &client_conf).replicas, 3);
 }

--- a/curvine-libsdk/java/src/main/java/io/curvine/CurvineNative.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/CurvineNative.java
@@ -390,6 +390,16 @@ public class CurvineNative {
             long nativeHandle, String sourcePath, String targetPath, boolean overwrite)
             throws IOException;
 
+    /**
+     * Submit a UFS-to-Curvine load job with an explicit replica count.
+     *
+     * @param replicas replica count for this job
+     * @return serialized {@code SubmitJobResponse} protobuf bytes
+     */
+    public static native byte[] submitLoadJobWithReplicas(
+            long nativeHandle, String sourcePath, String targetPath, boolean overwrite, int replicas)
+            throws IOException;
+
     /** Submit a Curvine-to-UFS export job. */
     public static native byte[] submitExportJob(
             long nativeHandle, String sourcePath, boolean overwrite) throws IOException;

--- a/curvine-libsdk/java/src/main/java/io/curvine/CurvineTransferClient.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/CurvineTransferClient.java
@@ -61,11 +61,21 @@ public final class CurvineTransferClient implements Closeable {
     /** Submit a UFS-to-Curvine load job. */
     public LoadJobResult submitLoad(LoadJobRequest request) throws IOException {
         Objects.requireNonNull(request, "request");
-        return filesystem.withOpen(nativeHandle -> parseSubmitResponse(CurvineNative.submitLoadJob(
-                nativeHandle,
-                request.getSourcePath(),
-                request.getTargetPath(),
-                request.isOverwrite())));
+        return filesystem.withOpen(nativeHandle -> {
+            byte[] response = request.getReplicas() == null
+                    ? CurvineNative.submitLoadJob(
+                            nativeHandle,
+                            request.getSourcePath(),
+                            request.getTargetPath(),
+                            request.isOverwrite())
+                    : CurvineNative.submitLoadJobWithReplicas(
+                            nativeHandle,
+                            request.getSourcePath(),
+                            request.getTargetPath(),
+                            request.isOverwrite(),
+                            request.getReplicas());
+            return parseSubmitResponse(response);
+        });
     }
 
     /**

--- a/curvine-libsdk/java/src/main/java/io/curvine/LoadJobRequest.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/LoadJobRequest.java
@@ -23,11 +23,13 @@ public final class LoadJobRequest {
     private final String sourcePath;
     private final String targetPath;
     private final boolean overwrite;
+    private final Integer replicas;
 
     private LoadJobRequest(Builder builder) {
         this.sourcePath = builder.sourcePath;
         this.targetPath = builder.targetPath;
         this.overwrite = builder.overwrite;
+        this.replicas = builder.replicas;
     }
 
     public String getSourcePath() {
@@ -43,6 +45,11 @@ public final class LoadJobRequest {
         return overwrite;
     }
 
+    /** Optional replica count for this load job. */
+    public Integer getReplicas() {
+        return replicas;
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -51,6 +58,7 @@ public final class LoadJobRequest {
         private String sourcePath;
         private String targetPath;
         private boolean overwrite = true;
+        private Integer replicas;
 
         private Builder() {
         }
@@ -70,12 +78,20 @@ public final class LoadJobRequest {
             return this;
         }
 
+        public Builder replicas(int replicas) {
+            this.replicas = replicas;
+            return this;
+        }
+
         public LoadJobRequest build() {
             if (sourcePath == null || sourcePath.trim().isEmpty()) {
                 throw new IllegalArgumentException("sourcePath cannot be empty");
             }
             if (targetPath != null && targetPath.trim().isEmpty()) {
                 throw new IllegalArgumentException("targetPath cannot be empty when set");
+            }
+            if (replicas != null && replicas <= 0) {
+                throw new IllegalArgumentException("replicas must be greater than zero");
             }
             return new LoadJobRequest(this);
         }

--- a/curvine-libsdk/java/src/test/java/io/curvine/LoadJobClientTest.java
+++ b/curvine-libsdk/java/src/test/java/io/curvine/LoadJobClientTest.java
@@ -62,6 +62,22 @@ public class LoadJobClientTest {
     }
 
     @Test
+    public void requestBuilderSupportsPositiveReplicas() {
+        LoadJobRequest request = LoadJobRequest.builder()
+                .sourcePath("s3://bucket/a")
+                .replicas(3)
+                .build();
+        Assert.assertEquals(Integer.valueOf(3), request.getReplicas());
+
+        try {
+            LoadJobRequest.builder().sourcePath("s3://bucket/a").replicas(0).build();
+            Assert.fail("expected IllegalArgumentException");
+        } catch (IllegalArgumentException expected) {
+            Assert.assertTrue(expected.getMessage().contains("replicas"));
+        }
+    }
+
+    @Test
     public void terminalStateDetectionMatchesForceRetrySemantics() {
         Assert.assertFalse(CurvineTransferClient.isTerminal(JobTaskStateProto.PENDING));
         Assert.assertFalse(CurvineTransferClient.isTerminal(JobTaskStateProto.LOADING));


### PR DESCRIPTION
# Summary

Add a per-job replica setting to the Java load API and carry it through the existing Transfer command path to the Worker. Existing Java load calls that omit replicas retain their current JNI path, idempotency key, and default replica behavior. Invalid stored replica options are ignored and fall back to existing defaults.

# Issue Describe / Design

Related to None.

The implementation reuses `TransferCommand.options` instead of adding an RPC field or a storage migration. An explicit replica count is validated at the Java, JNI, SDK, and Transfer service boundaries. The model accessor also accepts only positive persisted values, protecting planning from malformed historical data.

The effective priority is: job replicas > mount replicas > Transfer service client default. Explicit replicas are included in the generated client request ID so requests for the same paths with different replica counts do not reuse an existing idempotent job.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-libsdk/java` | Add `LoadJobRequest.Builder.replicas(int)` and a dedicated JNI call for explicit replicas. | Calls without replicas continue to use the original JNI symbol. |
| `curvine-sdk-core` | Convert load replicas into a Transfer command option and validate it. | Transfer loads now accept positive per-job replicas; other unsupported load options remain rejected. |
| `curvine-data-transfer` | Validate stored command options and prioritize job replicas during planning. | Explicit job replicas override mount and service defaults. |
| `curvine-model` | Add Transfer command replica helpers and replica-aware request IDs. | Unspecified replicas preserve existing request IDs; malformed stored values do not override defaults. |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `make format` | PASS | Project formatting target completed. |
| `cargo test -p curvine-model --test transfer_command_test` | PASS | Legacy request IDs and malformed replica values. |
| `cargo test -p curvine-sdk-core allows_replicas_and_rejects_unsupported_transfer_load_options` | PASS | Transfer compatibility validation. |
| `cargo test -p curvine-data-transfer --features transfer load_replicas_override_mount_and_service_defaults` | PASS | Per-job replica priority. |
| `cargo check -p curvine-libsdk-java` | PASS | JNI bridge compilation. |
| `mvn -q -Dtest=LoadJobClientTest test` | PASS | 13 tests, 0 failures. |
| `cargo clippy -p curvine-data-transfer --features transfer --tests -- -D warnings` | PASS | Reproduces and verifies the CI test-target failure. |
| `cargo clippy --all-targets --jobs 4 -- -D warnings --allow clippy::uninlined-format-args` | PASS | Matches the compile CI static-analysis command. |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None