### PR TITLE
test(image): preinstall pinned LTP 20250930

### DIFF
--- a/curvine-tests/Dockerfile
+++ b/curvine-tests/Dockerfile
@@ -5,6 +5,7 @@
 FROM ghcr.io/curvineio/curvine-compile:rocky9
 
 # Python + Flask + Werkzeug (build-server) and regression helpers; no runtime pip installs in CI.
+# bison/flex are required to build LTP from the release tarball.
 RUN dnf install -y dnf-plugins-core epel-release && \
     dnf config-manager --set-enabled crb && \
     dnf install -y \
@@ -18,7 +19,30 @@ RUN dnf install -y dnf-plugins-core epel-release && \
         zlib-static \
         jq \
         fio \
+        bison \
+        flex \
+        bzip2 \
+        fuse \
+        fuse-libs \
     && dnf clean all
+
+# Preinstall pinned LTP into /opt/ltp (runltp era; do not bump to >=20260529
+# without kirk migration). Version is intentionally inlined here so the image
+# does not depend on the still-evolving cvtest repo at build time. Align with
+# cvtest's LTP_VERSION when promoting a new pin.
+ARG LTP_VERSION=20250930
+RUN curl -fL --retry 8 --retry-all-errors --retry-delay 5 \
+      -o /tmp/ltp-full-${LTP_VERSION}.tar.bz2 \
+      "https://github.com/linux-test-project/ltp/releases/download/${LTP_VERSION}/ltp-full-${LTP_VERSION}.tar.bz2" \
+ && tar -xjf /tmp/ltp-full-${LTP_VERSION}.tar.bz2 -C /tmp \
+ && cd /tmp/ltp-full-${LTP_VERSION} \
+ && ./configure --prefix=/opt/ltp \
+ && make -j"$(nproc)" -k \
+ && make install -k \
+ && test -x /opt/ltp/runltp \
+ && test -d /opt/ltp/runtest \
+ && rm -rf /tmp/ltp-full-${LTP_VERSION}* \
+ && echo "LTP ${LTP_VERSION} installed at /opt/ltp"
 
 # Rust proxy (rsproxy.cn) for rustup updates and cargo crate downloads
 ENV RUSTUP_DIST_SERVER="https://rsproxy.cn"

--- a/curvine-tests/Dockerfile
+++ b/curvine-tests/Dockerfile
@@ -27,20 +27,22 @@ RUN dnf install -y dnf-plugins-core epel-release && \
     && dnf clean all
 
 # Preinstall pinned LTP into /opt/ltp (runltp era; do not bump to >=20260529
-# without kirk migration). Version is intentionally inlined here so the image
-# does not depend on cvtest at build time. Align with cvtest's LTP_VERSION
-# when promoting a new pin. Curated runtest files (fs-cv-smoke, …) are NOT
-# copied in — Portal uses stock suites; CI uses `cvtest run` to install them.
+# without kirk migration). Version and checksum are intentionally inlined here
+# so the image does not depend on cvtest at build time. Align both values when
+# promoting a new pin. Curated runtest files (fs-cv-smoke, …) are NOT copied in
+# — Portal uses stock suites; CI uses `cvtest run` to install them.
 #
-# make -k: same as cvtest tools/ltp/install-ltp.sh — a few unrelated
-# testcases may fail to compile on this base image; -k continues so the
-# install tree still completes. We still require runltp + runtest to exist.
+# A few unrelated testcases may fail to compile on this base image. Build and
+# install with -k to complete as many targets as possible, tolerate make's
+# aggregate failure status, then require runltp + runtest to exist.
 # listmount04 is dropped up front on uapi >= 6.17 (compile break; irrelevant
 # to FUSE POSIX validation), matching the cvtest installer.
 ARG LTP_VERSION=20250930
+ARG LTP_SHA256=fd20d451ff95fb2e1857a55132382bcd4246221d8cea3808cb32742ac513f245
 RUN curl -fL --retry 8 --retry-all-errors --retry-delay 5 \
       -o /tmp/ltp-full-${LTP_VERSION}.tar.bz2 \
       "https://github.com/linux-test-project/ltp/releases/download/${LTP_VERSION}/ltp-full-${LTP_VERSION}.tar.bz2" \
+ && echo "${LTP_SHA256}  /tmp/ltp-full-${LTP_VERSION}.tar.bz2" | sha256sum -c - \
  && tar -xjf /tmp/ltp-full-${LTP_VERSION}.tar.bz2 -C /tmp \
  && cd /tmp/ltp-full-${LTP_VERSION} \
  && if echo '#include <linux/mount.h>
@@ -52,8 +54,8 @@ int main(void){struct mnt_id_req r;return r.spare;}' \
      rm -f testcases/kernel/syscalls/listmount/listmount04.c; \
    fi \
  && ./configure --prefix=/opt/ltp \
- && make -j"$(nproc)" -k \
- && make install -k \
+ && (make -j"$(nproc)" -k || echo "WARNING: some LTP targets failed to build; validating required artifacts") \
+ && (make install -k || echo "WARNING: some LTP targets failed to install; validating required artifacts") \
  && test -x /opt/ltp/runltp \
  && test -d /opt/ltp/runtest \
  && rm -rf /tmp/ltp-full-${LTP_VERSION}* \

--- a/curvine-tests/Dockerfile
+++ b/curvine-tests/Dockerfile
@@ -28,14 +28,29 @@ RUN dnf install -y dnf-plugins-core epel-release && \
 
 # Preinstall pinned LTP into /opt/ltp (runltp era; do not bump to >=20260529
 # without kirk migration). Version is intentionally inlined here so the image
-# does not depend on the still-evolving cvtest repo at build time. Align with
-# cvtest's LTP_VERSION when promoting a new pin.
+# does not depend on cvtest at build time. Align with cvtest's LTP_VERSION
+# when promoting a new pin. Curated runtest files (fs-cv-smoke, …) are NOT
+# copied in — Portal uses stock suites; CI uses `cvtest run` to install them.
+#
+# make -k: same as cvtest tools/ltp/install-ltp.sh — a few unrelated
+# testcases may fail to compile on this base image; -k continues so the
+# install tree still completes. We still require runltp + runtest to exist.
+# listmount04 is dropped up front on uapi >= 6.17 (compile break; irrelevant
+# to FUSE POSIX validation), matching the cvtest installer.
 ARG LTP_VERSION=20250930
 RUN curl -fL --retry 8 --retry-all-errors --retry-delay 5 \
       -o /tmp/ltp-full-${LTP_VERSION}.tar.bz2 \
       "https://github.com/linux-test-project/ltp/releases/download/${LTP_VERSION}/ltp-full-${LTP_VERSION}.tar.bz2" \
  && tar -xjf /tmp/ltp-full-${LTP_VERSION}.tar.bz2 -C /tmp \
  && cd /tmp/ltp-full-${LTP_VERSION} \
+ && if echo '#include <linux/mount.h>
+int main(void){struct mnt_id_req r;return r.spare;}' \
+       | gcc -x c - -o /dev/null 2>/dev/null; then \
+     :; \
+   else \
+     echo "kernel uapi incompatible with listmount04; dropping it"; \
+     rm -f testcases/kernel/syscalls/listmount/listmount04.c; \
+   fi \
  && ./configure --prefix=/opt/ltp \
  && make -j"$(nproc)" -k \
  && make install -k \


### PR DESCRIPTION
# Summary

Preinstall pinned LTP 20250930 into `/opt/ltp` in the `curvine-tests` image so regression and Portal runs can use `runltp` without a separate host-side installation. The build verifies the pinned release checksum and tolerates unrelated testcase build failures only when the required installed artifacts are present.

# Issue Describe / Design

No linked issue.

- LTP is pinned to `20250930`, the last selected release that still ships the legacy `runltp` runner used by Portal and cvtest. Do not bump to `>=20260529` without migrating consumers to kirk and adapting its output format.
- The release tarball is verified against the pinned upstream SHA256 before extraction. `LTP_VERSION` and `LTP_SHA256` must be updated together.
- LTP is built and installed with `make -k` so independent targets can complete. GNU make still returns a non-zero aggregate status when any target fails, so that status is logged and the image build is gated by explicit checks for `/opt/ltp/runltp` and `/opt/ltp/runtest`.
- `listmount04` is removed when the kernel UAPI is incompatible, matching the cvtest installer.
- Curated cvtest runtest files are not baked into the image. Portal uses stock suites, while CI installs curated suites through `cvtest run`.

This is PR-A of two. A follow-up PR will add `e2e-ltp.yml` for the cvtest three-lane CI; that workflow installs LTP at job runtime and does not depend on this image.

After merge, a maintainer should dispatch **Build Tests Docker Image** on `main` with `push_image=true` to publish the `rocky9-amd64`, `rocky9-arm64`, and multi-architecture tags.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-tests/Dockerfile` | Add LTP build dependencies and install pinned LTP 20250930 into `/opt/ltp` | The regression image now includes stock LTP suites and `runltp` |
| `curvine-tests/Dockerfile` | Verify the downloaded tarball with pinned SHA256 | The build fails before extraction if the artifact is corrupted or replaced |
| `curvine-tests/Dockerfile` | Continue after `make -k` aggregate failures and validate required artifacts | Unrelated testcase compilation failures no longer abort an otherwise usable image |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `git diff --check` | PASS | No whitespace errors |
| Compile and Smoke Test | PASS | Linux CI passed fmt, clippy, build, and smoke checks for commit `e1eb3545` |
| `make format` (local macOS) | ENVIRONMENT BLOCKED | Existing platform-specific `curvine-sys` / `curvine-fuse` errors; equivalent Linux CI checks passed |
| `docker build -f curvine-tests/Dockerfile ...` | NOT RUN LOCALLY | Docker/Podman runtime is unavailable on the development host; use the dedicated workflow with `push_image=false` before merge |

# Dependencies

- Related PRs: Follow-up `e2e-ltp.yml` PR not opened yet
- Related issues: None
- Blocks / blocked by: None
