### PR TITLE
ci: run focused POSIX smoke in existing build job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,9 @@ env:
   CARGO_TERM_COLOR: always
   # Tune build parallelism: 4 uses more CPU on standard 4-vCPU runner; set to 2 if OOM
   CARGO_BUILD_JOBS: 4
+  CVTEST_REPO: CurvineIO/cvtest
+  CVTEST_REF: 5d7ea3052e7a812289d1a8e57aeddda0cb7af425
+  MOUNT_PATH: /curvine-fuse
 
 jobs:
   # Speed note: slowness is from runner CPU/RAM (standard = 4 vCPU, ~16GB), not container size.
@@ -37,9 +40,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: cleanup
-    # curvine-tests image extends curvine-compile:rocky9 and pre-installs Flask, werkzeug, pip, jq, fio (see curvine-tests/Dockerfile)
+    timeout-minutes: 90
+    # curvine-tests extends curvine-compile:rocky9 and includes the build tools,
+    # FUSE userspace packages, and pinned LTP used by the PR POSIX smoke test.
     container:
       image: ghcr.io/curvineio/curvine-tests:rocky9
+      options: --privileged --device /dev/fuse
     
     steps:
       - uses: actions/checkout@v4
@@ -125,6 +131,88 @@ jobs:
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           make check-minimal-artifact-deps
 
+      - name: Checkout cvtest for POSIX smoke
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.CVTEST_REPO }}
+          ref: ${{ env.CVTEST_REF }}
+          path: cvtest
+
+      - name: Assemble POSIX smoke distribution from existing build
+        if: github.event_name == 'pull_request'
+        run: |
+          set -euo pipefail
+          test -x target/debug/curvine-server
+          test -x target/debug/curvine-fuse
+          test -x /opt/ltp/runltp
+
+          rm -rf build/dist
+          mkdir -p build/dist/bin build/dist/conf build/dist/lib
+          cp -a build/bin/. build/dist/bin/
+          cp -a etc/. build/dist/conf/
+          install -m 0755 target/debug/curvine-server build/dist/lib/curvine-server
+          install -m 0755 target/debug/curvine-fuse build/dist/lib/curvine-fuse
+          chmod +x build/dist/bin/*
+
+      - name: Start cluster and mount FUSE for POSIX smoke
+        if: github.event_name == 'pull_request'
+        run: |
+          set -euo pipefail
+          mkdir -p "$MOUNT_PATH"
+          cd build/dist
+          ./bin/curvine-master.sh restart
+          sleep 5
+          ./bin/curvine-worker.sh restart
+          sleep 5
+          ./bin/curvine-fuse.sh restart -d
+          python3 - <<'EOF'
+          import os, time, sys
+          p = os.path.join(os.environ["MOUNT_PATH"], ".ci-ready")
+          payload = b"ci" * 8192
+          deadline = time.time() + 120
+          while time.time() < deadline:
+              try:
+                  with open(p, "wb") as f:
+                      f.write(payload)
+                  with open(p, "rb") as f:
+                      assert f.read() == payload
+                  os.unlink(p)
+                  sys.exit(0)
+              except OSError:
+                  time.sleep(2)
+          print("data path not ready after 120s", file=sys.stderr)
+          sys.exit(1)
+          EOF
+
+      - name: Run focused POSIX smoke
+        if: github.event_name == 'pull_request'
+        run: |
+          set -euo pipefail
+          mkdir -p ltp-results
+
+          suite="$(sed -e '/^[[:space:]]*#/d' -e '/^[[:space:]]*$/d' \
+            cvtest/suites/ci-fast.txt)"
+          if [ "$suite" != "ltp:posix-cv-smoke" ]; then
+            echo "Expected ci-fast.txt to contain only ltp:posix-cv-smoke, found:" >&2
+            printf '%s\n' "$suite" >&2
+            exit 1
+          fi
+
+          ./cvtest/cvtest run --suite "$suite" --mount "$MOUNT_PATH" \
+            --json "$GITHUB_WORKSPACE/ltp-results/ltp-posix-cv-smoke.json" \
+            --log "$GITHUB_WORKSPACE/ltp-results/ltp-posix-cv-smoke.log"
+
+      - name: Print LTP diagnostics
+        if: ${{ failure() && github.event_name == 'pull_request' }}
+        run: |
+          for log_file in build/dist/logs/*.out ltp-results/*.log; do
+            if [ -f "$log_file" ]; then
+              echo "===== ${log_file} ====="
+              tail -n 200 "$log_file"
+            fi
+          done
+
       # - name: Run unit tests (skip UFS-dependent tests in CI)
       #   env:
       #     NEXTEST_CI_NO_UFS: "1"
@@ -141,6 +229,7 @@ jobs:
         # On failure, summary is written to GitHub Step Summary; step exits non-zero so pipeline fails.
 
       - name: Final cleanup before cache save
+        if: always()
         run: |
           echo "Final cleanup before cache save"
           

--- a/curvine-tests/README.md
+++ b/curvine-tests/README.md
@@ -68,8 +68,22 @@ The dashboard shows all modules with **Run / Cancel** buttons.
 | **FIO** | FIO performance tests (needs a running cluster) |
 | **LTP** | POSIX compliance tests via LTP (needs `/opt/ltp` and cluster) |
 
-> **Dailytest** does not include LTP by default. Trigger LTP separately via the Portal or `/ltp/run` API.  
+> **Dailytest** does not include LTP by default. Trigger LTP separately via the Portal or `/ltp/run` API.
 > LTP requires LTP installed at `/opt/ltp` on the host or in the container.
+>
+> **cvtest (external, preferred for CI)**: the [cvtest repo](https://github.com/CurvineIO/cvtest)
+> maintains the pinned LTP installer (version pinned there — single source
+> of truth), curated suites (`posix-cv-smoke` / `fs-cv` / `syscalls-cv`, …),
+> and the `cvtest run` entrypoint whose JSON matches this Portal's
+> `ltp_test` schema. This repo only invokes it; bumping the LTP version
+> happens in cvtest, not here. PR CI reads the pinned cvtest `ci-fast.txt`
+> manifest, which currently contains only the 53-case `ltp:posix-cv-smoke`
+> suite. It runs in the existing build job and reuses the binaries that job
+> already compiled. Generic `smoketest`, `fs-cv-smoke`, full `syscalls-cv`,
+> and pressure suites are intentionally excluded. The Portal path above stays
+> for local/interactive use with **stock** LTP suites only (`smoketest`,
+> `fs_perms_simple`, `fcntl-locktests`, `fs_bind`). Curated suites such as
+> `posix-cv-smoke` require `cvtest run` — they are not in the stock LTP tree.
 
 Test results are saved under `curvine-tests/regression_result/<timestamp>/`.
 


### PR DESCRIPTION
# Summary

Run only the focused 53-case Curvine POSIX/filesystem-semantics suite for pull requests inside the existing Compile and Smoke Test build job. The test reuses the `curvine-server` and `curvine-fuse` debug binaries already produced by that job and does not upload artifacts.

# Issue Describe / Design

No linked issue.

- Reuse the existing build output instead of running a second full `make build`.
- Assemble only the runtime layout needed to start master, worker, and FUSE.
- Run in the published `curvine-tests:rocky9` image, which already contains pinned LTP 20250930.
- Pin cvtest to merge commit `5d7ea3052e7a812289d1a8e57aeddda0cb7af425`.
- Read cvtest's `suites/ci-fast.txt` manifest and require its only active entry to be `ltp:posix-cv-smoke`.
- Do not run generic `smoketest`, `fs-cv-smoke`, full `syscalls-cv`, or pressure suites in regular PR CI.
- Keep results only on the ephemeral runner and print failure diagnostics to the job log; no Actions artifact storage is used.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `.github/workflows/build.yml` | Add PR-only focused POSIX smoke after the existing build, with privileged FUSE access | Pull request builds validate the 53 cases from `ltp:posix-cv-smoke`; no separate LTP jobs are generated |
| `curvine-tests/README.md` | Document the pinned cvtest fast manifest and excluded suites | Documentation matches the single-job, focused POSIX design |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `git diff --check` | PASS | No whitespace errors in the final squashed diff |
| `cargo fmt --check` | PASS | Formatting is clean |
| Workflow YAML parse | PASS | `.github/workflows/build.yml` parses successfully |
| Local cvtest validation | PASS | `ltp:posix-cv-smoke` passed 53/53 on Rocky Linux 9 + LTP 20250930 + Curvine FUSE in 16 seconds |
| [GitHub Actions PR run](https://github.com/CurvineIO/curvine/actions/runs/34337112339) | PASS | `ltp:posix-cv-smoke` passed 53/53 in 18 seconds; complete build job finished in 5m31s |

# Dependencies

- Related PRs: #1675, [CurvineIO/cvtest#2](https://github.com/CurvineIO/cvtest/pull/2)
- Related issues: None
- Blocks / blocked by: Requires `ghcr.io/curvineio/curvine-tests:rocky9` from #1675 and pinned cvtest commit `5d7ea3052e7a812289d1a8e57aeddda0cb7af425`
