### PR TITLE
fix(master): narrow resize_by_id lock scope and rebuild via inode id (#1671)

### DIFF
--- a/curvine-master/src/master/fs/master_filesystem.rs
+++ b/curvine-master/src/master/fs/master_filesystem.rs
@@ -1694,15 +1694,13 @@ impl MasterFilesystem {
             self.worker_manager.write().remove_blocks(&del_res);
         }
 
-        let blocks = self.get_block_locations(path)?;
-        if blocks.status.id != inode_id {
-            return err_box!(
-                "Path {} resolved to different inode after resize, expected {}, got {}",
-                path,
-                inode_id,
-                blocks.status.id
-            );
-        }
+        let blocks = {
+            let fs_dir = self.fs_dir.read();
+            let inode = Self::resolve_file_inode(&fs_dir, path, Some(inode_id))?;
+            let file = inode.as_file_ref()?;
+            let locs = self.get_block_locs(path, &fs_dir, file)?;
+            FileBlocks::new(inode.to_file_status(path)?, locs)
+        };
 
         Ok(blocks)
     }

--- a/curvine-master/src/master/fs/master_filesystem.rs
+++ b/curvine-master/src/master/fs/master_filesystem.rs
@@ -1680,25 +1680,29 @@ impl MasterFilesystem {
             self.worker_manager.read().available_bytes()
         };
 
-        let mut fs_dir = self.fs_dir.write();
-        let (del_res, inode) = {
+        let (del_res, inode_id) = {
+            let mut fs_dir = self.fs_dir.write();
             let mut inode = Self::resolve_file_inode(&fs_dir, path, inode_id)?;
             let file = inode.as_file_ref()?;
             Self::validate_alloc_capacity(file.len, file.replicas, &opts, available)?;
+            let inode_id = inode.id();
             let del_res = fs_dir.resize_inode(path, &mut inode, opts)?;
-            (del_res, inode)
+            (del_res, inode_id)
         };
 
         if !del_res.blocks.is_empty() {
             self.worker_manager.write().remove_blocks(&del_res);
         }
 
-        let blocks = {
-            let file = inode.as_file_ref()?;
-            let locs = self.get_block_locs(path, &fs_dir, file)?;
-            let status = inode.to_file_status(path)?;
-            FileBlocks::new(status, locs)
-        };
+        let blocks = self.get_block_locations(path)?;
+        if blocks.status.id != inode_id {
+            return err_box!(
+                "Path {} resolved to different inode after resize, expected {}, got {}",
+                path,
+                inode_id,
+                blocks.status.id
+            );
+        }
 
         Ok(blocks)
     }


### PR DESCRIPTION
<!-- curvine-automation:pr:CurvineIO/curvine:1671 -->

# Summary

Fixes a lock-scope regression in `resize_by_id` introduced by PR #1663, where `fs_dir.write()` was held across `worker_manager.remove_blocks()`. The fix releases the directory write lock before blocking on the worker manager and rebuilds the response via inode id so rename-sensitive resize paths remain correct.

# Issue Describe / Design

Closes #1671

**Root cause:** Commit `dc637c67` acquired `fs_dir.write()` at the start of `resize_by_id` and kept it while calling `worker_manager.write().remove_blocks()`, violating the lock-scope contract from PR #670 exercised by `resize_lock_scope_test`.

**Reproduction:**
1. Build Curvine at upstream/main `10e07353`.
2. Run `cargo test -p curvine-server resize_does_not_hold_fs_lock_while_waiting_worker_manager`.
3. The test panics because resize keeps `fs_dir` locked while waiting on `worker_manager`.

**Fix approach:**
1. Narrow `fs_dir` write lock scope to metadata mutation only, then call `worker_manager.remove_blocks()` after releasing it.
2. Rebuild `FileBlocks` by resolving the inode via captured `inode_id` so client paths that changed after rename still return the correct file status and block locations.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-master/src/master/fs/master_filesystem.rs` | Release `fs_dir` before `worker_manager.remove_blocks`; rebuild response via inode id | Restores PR #670 lock ordering; fixes integration failure after rename during resize |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test -p curvine-server resize_does_not_hold_fs_lock_while_waiting_worker_manager` | PASS | Fixed HEAD |
| fast profile | PASS | No new failures vs archived baseline |
| integration profile | PASS | Original resize lock-scope failure absent |
| daily profile | PASS | Original resize lock-scope failure absent |
| fuse profile | PASS | No new failures vs archived baseline |
| ltp profile | PASS | 1129 passed / 0 failed / 141 skipped |
| csi profile | PASS | Cleanup passed |
| `make format` | PASS | Formatting and clippy clean |

# Dependencies

- Related PRs: None
- Related issues: #1671
- Blocks / blocked by: None
