### PR TITLE
fix(tests): escape newline in LTP image compile probe (#1675)

### DIFF
--- a/curvine-tests/Dockerfile
+++ b/curvine-tests/Dockerfile
@@ -45,7 +45,7 @@ RUN curl -fL --retry 8 --retry-all-errors --retry-delay 5 \
  && echo "${LTP_SHA256}  /tmp/ltp-full-${LTP_VERSION}.tar.bz2" | sha256sum -c - \
  && tar -xjf /tmp/ltp-full-${LTP_VERSION}.tar.bz2 -C /tmp \
  && cd /tmp/ltp-full-${LTP_VERSION} \
- && if echo '#include <linux/mount.h>
+ && if echo '#include <linux/mount.h>\
 int main(void){struct mnt_id_req r;return r.spare;}' \
        | gcc -x c - -o /dev/null 2>/dev/null; then \
      :; \


### PR DESCRIPTION
# Summary

Fixes the `build-tests-image` workflow failure: the LTP compile probe in `curvine-tests/Dockerfile` was split across two lines without a Dockerfile line-continuation backslash, so the parser treated `int main(void){...}` as a new instruction and aborted with `dockerfile parse error on line 49: unknown instruction: int`.

# Issue Describe / Design

- **Root cause**: Dockerfile `RUN` lines continue only with a trailing `\`. The probe added in #1675 spans lines 48–49:

  ```
  && if echo '#include <linux/mount.h>
  int main(void){struct mnt_id_req r;return r.spare;}' \
  ```

  Line 48 has no trailing backslash, so line 49 begins a new instruction → parse error before the build even starts.
- **Reproduction**: `docker buildx build -f curvine-tests/Dockerfile .` on the affected commit fails with `unknown instruction: int (did you mean env?)`.
- **Fix approach**: add the continuation backslash after `'#include <linux/mount.h>\` so the entire gcc probe is one logical line. Inside single quotes, the backslash-newline is passed through as a literal line splice, which `gcc -x c` accepts for string literals.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-tests/Dockerfile` | Add trailing `\` after `'#include <linux/mount.h>` in the listmount04 compile probe | None — restores intended probe behavior; image now builds |

# Test verified

| Test case | Result | Notes |
| --------- | ----- | ----- |
| `docker build --check -f curvine-tests/Dockerfile .` | PASS | "Check complete, no warnings found" |
| Probe shell logic on host | PASS | Host uapi lacks `mnt_id_req` → correctly takes "drop listmount04" path |

# Dependencies

- Related PRs: #1675 (introduced the broken probe)
- Related issues: None
- Blocks / blocked by: None