### PR TITLE
docs(readme): add contributors section with contrib.rocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,12 +143,8 @@ Please read Curvine [Contribute guidelines](CONTRIBUTING.md)
 ## 📜 License
 Curvine is licensed under the ​**​[Apache License 2.0](LICENSE)​**.
 
-## Contributors
-
-Thanks to all contributors who help make Curvine better.
-
 <a href="https://github.com/CurvineIO/curvine/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=CurvineIO/curvine&max=500&columns=10&anon=1" alt="Contributors" />
+  <img src="https://contrib.rocks/image?repo=CurvineIO/curvine" />
 </a>
 
-Made with [contrib.rocks](https://contrib.rocks).
+Made with [contrib.rocks](https://contrib.rocks/).

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Curvine is licensed under the ​**​[Apache License 2.0](LICENSE)​**.
 Thanks to all contributors who help make Curvine better.
 
 <a href="https://github.com/CurvineIO/curvine/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=CurvineIO/curvine" alt="Contributors" />
+  <img src="https://contrib.rocks/image?repo=CurvineIO/curvine&max=500&columns=10&anon=1" alt="Contributors" />
 </a>
 
 Made with [contrib.rocks](https://contrib.rocks).

--- a/README.md
+++ b/README.md
@@ -142,3 +142,13 @@ Please read Curvine [Contribute guidelines](CONTRIBUTING.md)
 
 ## 📜 License
 Curvine is licensed under the ​**​[Apache License 2.0](LICENSE)​**.
+
+## Contributors
+
+Thanks to all contributors who help make Curvine better.
+
+<a href="https://github.com/CurvineIO/curvine/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=CurvineIO/curvine" alt="Contributors" />
+</a>
+
+Made with [contrib.rocks](https://contrib.rocks).


### PR DESCRIPTION
## Summary

- Add a **Contributors** section at the end of `README.md`
- Thank all contributors and display contributor avatars using [contrib.rocks](https://contrib.rocks)

## Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `README.md` | Add Contributors section with contrib.rocks image | None |

## Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `make format` | PASS | Required pre-commit formatting gate |
| README rendering | Manual | Markdown + contrib.rocks image link verified |

## Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None

Made with [Cursor](https://cursor.com)