### PR TITLE
fix(worker): abort block on deterministic finalize prepare failure (#1681)

### DIFF
--- a/curvine-worker/src/worker/block/block_store.rs
+++ b/curvine-worker/src/worker/block/block_store.rs
@@ -18,7 +18,7 @@ use crate::worker::storage::{
 };
 use crate::worker::Worker;
 use curvine_config::ClusterConf;
-use curvine_core_error::CommonResult;
+use curvine_core_error::{CommonError, CommonResult};
 use curvine_model::{ExtendedBlock, StorageInfo};
 use parking_lot::{Mutex, MutexGuard};
 use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
@@ -168,27 +168,64 @@ impl BlockStore {
         let started = Instant::now();
         let plan = reservation.prepare(block.len);
         self.observe_file_layout_operation("finalize", started.elapsed());
-        let result = match plan {
-            Ok(plan) => self.with_dataset_write("finalize", |state| {
-                state.publish_file_finalize(&reservation, plan)
-            }),
-            Err(error) => Err(error),
+        let plan = match plan {
+            Ok(plan) => plan,
+            Err(error) => {
+                if error.to_string().contains("length mismatch") {
+                    // Deterministic mismatch: retrying can never succeed, so
+                    // abort the block instead of looping forever.
+                    if let Err(abort) =
+                        self.with_dataset_write("finalize", |state| state.abort_block(block))
+                    {
+                        log::error!(
+                            "failed to abort block {} after prepare error {}: {}; rollback to Writing",
+                            block.id,
+                            error,
+                            abort
+                        );
+                        self.rollback_finalize_reservation(block.id, &abort, |state| {
+                            state.rollback_file_finalize(&reservation)
+                        });
+                    }
+                } else {
+                    // Transient failure: release the reservation so the block
+                    // returns to Writing and finalize can be retried.
+                    self.rollback_finalize_reservation(block.id, &error, |state| {
+                        state.rollback_file_finalize(&reservation)
+                    });
+                }
+                return Err(error);
+            }
         };
-        match result {
+
+        match self.with_dataset_write("finalize", |state| {
+            state.publish_file_finalize(&reservation, plan)
+        }) {
             Ok(meta) => Ok(meta),
             Err(error) => {
-                if let Err(rollback) = self.with_dataset_write("finalize", |state| {
+                self.rollback_finalize_reservation(block.id, &error, |state| {
                     state.rollback_file_finalize(&reservation)
-                }) {
-                    log::error!(
-                        "failed to roll back block {} finalization after {}: {}",
-                        block.id,
-                        error,
-                        rollback
-                    );
-                }
+                });
                 Err(error)
             }
+        }
+    }
+
+    /// Roll back a finalize reservation after a failed prepare or publish.
+    /// Failures are logged while the caller keeps the original error.
+    fn rollback_finalize_reservation(
+        &self,
+        block_id: i64,
+        reason: &CommonError,
+        rollback: impl FnOnce(&mut BlockDataset) -> CommonResult<()>,
+    ) {
+        if let Err(failed) = self.with_dataset_write("finalize", rollback) {
+            log::error!(
+                "failed to roll back block {} finalization after {}: {}",
+                block_id,
+                reason,
+                failed
+            );
         }
     }
 
@@ -562,6 +599,65 @@ mod tests {
 
         FileUtils::delete_path(&active_path, true)?;
         assert!(store.finalize_block(&block)?.is_final());
+        Ok(())
+    }
+
+    #[test]
+    fn failed_rewrite_finalize_with_shorter_length_restores_committed_block() -> CommonResult<()> {
+        let store = create_store_with_capacity("rewrite-shrink-abort", "16MB")?;
+        let mut block = ExtendedBlock::with_mem(1, "50B")?;
+        let finalized = finalize_block(&store, &block)?;
+        assert!(finalized.is_final());
+        let available = store.read()?.available();
+
+        let rewriting = store.open_block(&block)?;
+        assert_eq!(rewriting.state(), &BlockState::Writing);
+
+        block.len = 20;
+        let error = store.finalize_block(&block).unwrap_err();
+        assert!(
+            error.to_string().contains("length mismatch"),
+            "expected a length mismatch prepare failure, got: {error}"
+        );
+
+        let restored = store.get_block(block.id)?;
+        assert!(restored.is_final());
+        assert_eq!(restored.len(), 50);
+        let active_path = store
+            .short_circuit(&restored)?
+            .expect("file layout must expose a local path");
+        assert_eq!(std::fs::metadata(&active_path)?.len(), 50);
+
+        let (_, dir) = store.read()?.layout_for(&restored)?;
+        let staging = BlockMeta::new(block.id, block.len, &dir);
+        let staging_path = FileLayout::block_path(&dir, &staging)?;
+        assert!(!staging_path.exists());
+        assert_eq!(store.read()?.available(), available);
+        Ok(())
+    }
+
+    #[test]
+    fn failed_first_write_finalize_with_length_mismatch_aborts_block() -> CommonResult<()> {
+        let store = create_store_with_capacity("first-write-abort", "16MB")?;
+        let available = store.read()?.available();
+
+        let block = ExtendedBlock::with_mem(1, "50B")?;
+        let writing = store.open_block(&block)?;
+        assert_eq!(writing.state(), &BlockState::Writing);
+        let staging_path = store
+            .short_circuit(&writing)?
+            .expect("file layout must expose a local path");
+        write_block(&staging_path, 30)?;
+
+        let error = store.finalize_block(&block).unwrap_err();
+        assert!(
+            error.to_string().contains("length mismatch"),
+            "expected a length mismatch prepare failure, got: {error}"
+        );
+
+        assert!(store.get_block(block.id).is_err());
+        assert!(!std::path::Path::new(&staging_path).exists());
+        assert_eq!(store.read()?.available(), available);
         Ok(())
     }
 


### PR DESCRIPTION
# Summary

On a deterministic finalize prepare failure (client re-commits a length that cannot be materialized from staging), `finalize_block` now aborts the block instead of rolling it back to `Writing`, preventing it from being permanently stranded with a leaked staging copy that exhausted worker capacity and hung resident clients.

# Issue Describe / Design

Closes #1681

**Root cause**

`finalize_block` treated prepare-stage and publish-stage failures identically, rolling both back to `Writing` via `rollback_file_finalize`. That rollback only restores the block state; it does not discard the stale staging copy, clear `committed_rewrites`, or release the reserved space.

A prepare failure is deterministic: after a worker restart a rewrite copies the larger committed generation into staging, then a resident client re-commits a shorter length, and grow-only `prepare_finalize` rejects it with `length mismatch` (`crates/adapters/curvine-storage-local/src/layout/file_layout.rs:117`). Because `Writing` is active but not final, a later re-open skips `prepare_write`'s copy and reuses the stale staging, and re-finalize fails identically - an infinite loop that leaks ~2x reserved space per stuck block until the worker runs out of capacity and every later write fails. The resident Java RSS SDK surfaces this as a hang on `close`.

**Reproduction**

Finalize a 50B block -> reopen for rewrite (staging copied from committed) -> re-commit 20B -> finalize fails at the prepare length check -> block rolled back to `Writing` with staging + reservation left behind -> re-open/re-finalize loops forever.

**Fix approach**

Distinguish the two stages:

- prepare failure (deterministic) -> `abort_block`: discard staging, restore the last committed generation (or drop a first-write block), reclaim the reserved space, then return the original `length mismatch` error. The error still propagates; only the stranded state is removed.
- publish failure (transient, at the atomic rename) -> keep `rollback_file_finalize` so a retry reuses the same staging without re-copying.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-worker/src/worker/block/block_store.rs` | `finalize_block`: on prepare failure call `state.abort_block(block)` and return the original error; keep `rollback_file_finalize` for publish failure. Add regression test. | Prepare failures now restore the committed generation and reclaim space instead of stranding the block in `Writing`. Publish-failure rollback path and the returned error are unchanged. |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test -p curvine-worker finalize` (Linux) | PASS | New `failed_rewrite_finalize_with_shorter_length_restores_committed_block` and existing `failed_file_finalize_restores_writing_state` both pass |

Formatting/lint (`make format`) not run locally (Windows dev environment); changes follow the surrounding rustfmt style.

# Dependencies

- Related PRs: None
- Related issues: #1681
- Blocks / blocked by: None
