### PR TITLE
fix(config): replace nix ifaddrs with cross-platform if-addrs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4264,7 +4264,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bae14dba30b8dcc4905a9189ebb18bc9db9744ef0ad8f2b94ef00d21e176964"
 dependencies = [
- "bindgen 0.69.5",
+ "bindgen 0.70.1",
  "libc",
 ]
 
@@ -6957,7 +6957,6 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
- "memoffset",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2238,8 +2238,8 @@ dependencies = [
  "curvine-rpc",
  "curvine-runtime",
  "curvine-sys",
+ "if-addrs",
  "log",
- "nix",
  "regex",
  "serde",
  "toml",
@@ -4264,7 +4264,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bae14dba30b8dcc4905a9189ebb18bc9db9744ef0ad8f2b94ef00d21e176964"
 dependencies = [
- "bindgen 0.70.1",
+ "bindgen 0.69.5",
  "libc",
 ]
 
@@ -5362,6 +5362,16 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "if-addrs"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b2eeee38fef3aa9b4cc5f1beea8a2444fc00e7377cafae396de3f5c2065e24"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,6 +169,7 @@ rocksdb = { version = "0.22.0", default-features = false, features = ["lz4"] }
 raft = { version = "0.7.0", features = ["prost-codec"], default-features = false }
 trait-variant = "0.1.2"
 nix = { version = "0.30.1", features = ["ioctl", "user", "event"] }
+if-addrs = "0.13"
 rusqlite = { version = "0.32.1", features = ["bundled"] }
 mysql = "25.0.1"
 native-tls = "0.2.18"

--- a/crates/common/curvine-config/Cargo.toml
+++ b/crates/common/curvine-config/Cargo.toml
@@ -20,7 +20,7 @@ serde = { workspace = true }
 toml = { workspace = true }
 clap = { workspace = true }
 log = { workspace = true }
-nix = { workspace = true, features = ["net"] }
+if-addrs = { workspace = true }
 regex = { workspace = true }
 
 [features]

--- a/crates/common/curvine-config/src/cluster_conf.rs
+++ b/crates/common/curvine-config/src/cluster_conf.rs
@@ -385,14 +385,10 @@ impl ClusterConf {
         Ok(toml::to_string_pretty(self)?)
     }
 
-    /// Resolve the local IPv4 address bound to the named network interface
-    /// (e.g. `eth0` on Unix, the adapter friendly name on Windows).
+    /// Resolve the local IPv4 address bound to the named network interface.
     ///
-    /// Enumerates the host's interface addresses (via `getifaddrs(3)` on Unix,
-    /// `GetAdaptersAddresses` on Windows) and returns the first IPv4 address
-    /// whose interface name matches `interface`. Returns an error if the
-    /// interface does not exist or has no IPv4 address assigned (an IPv6-only
-    /// interface yields no match).
+    /// Returns the first IPv4 address of the named interface (`eth0`-style name on Unix,
+    /// adapter friendly name on Windows), or an error if it has none.
     pub fn interface_ipv4<T: AsRef<str>>(interface: T) -> CommonResult<String> {
         let interface = interface.as_ref();
         let addrs = try_err!(if_addrs::get_if_addrs());
@@ -483,16 +479,25 @@ mod tests {
         assert_eq!(conf.cluster_id, "curvine");
     }
 
-    // The loopback interface is present on every supported host and always
-    // carries 127.0.0.1, so it is a stable target for the happy path.
+    // Discover the loopback interface by its 127.0.0.1 address instead of
+    // hard-coding `lo`: on Windows if-addrs reports the adapter friendly name
+    // (locale-dependent), so the interface name differs across platforms.
+    fn loopback_name() -> String {
+        if_addrs::get_if_addrs()
+            .expect("failed to enumerate network interfaces")
+            .into_iter()
+            .find(|ifaddr| {
+                ifaddr.ip() == std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST)
+            })
+            .expect("a loopback interface carrying 127.0.0.1 must exist")
+            .name
+    }
+
     #[test]
     fn interface_ipv4_resolves_loopback() {
-        #[cfg(target_os = "macos")]
-        let loopback = "lo0";
-        #[cfg(not(target_os = "macos"))]
-        let loopback = "lo";
+        let loopback = loopback_name();
 
-        let ip = ClusterConf::interface_ipv4(loopback)
+        let ip = ClusterConf::interface_ipv4(&loopback)
             .expect("loopback interface must resolve to an IPv4 address");
         assert_eq!(ip, "127.0.0.1");
     }
@@ -756,10 +761,7 @@ mod tests {
     // file-configured hostnames.
     #[test]
     fn from_resolves_all_hostnames_via_net_interface() {
-        #[cfg(target_os = "macos")]
-        let loopback = "lo0";
-        #[cfg(not(target_os = "macos"))]
-        let loopback = "lo";
+        let loopback = loopback_name();
 
         let path = std::env::temp_dir().join(format!(
             "curvine-full-nic-{}-{}.toml",
@@ -802,10 +804,7 @@ mod tests {
 
     #[test]
     fn transfer_net_interface_keeps_master_address() {
-        #[cfg(target_os = "macos")]
-        let loopback = "lo0";
-        #[cfg(not(target_os = "macos"))]
-        let loopback = "lo";
+        let loopback = loopback_name();
 
         // Transfer-scoped env layer resolves only client/transfer hostnames
         // from the NIC; master/journal entries keep their file values, so the

--- a/crates/common/curvine-config/src/cluster_conf.rs
+++ b/crates/common/curvine-config/src/cluster_conf.rs
@@ -486,9 +486,7 @@ mod tests {
         if_addrs::get_if_addrs()
             .expect("failed to enumerate network interfaces")
             .into_iter()
-            .find(|ifaddr| {
-                ifaddr.ip() == std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST)
-            })
+            .find(|ifaddr| ifaddr.ip() == std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST))
             .expect("a loopback interface carrying 127.0.0.1 must exist")
             .name
     }

--- a/crates/common/curvine-config/src/cluster_conf.rs
+++ b/crates/common/curvine-config/src/cluster_conf.rs
@@ -26,9 +26,9 @@ use curvine_rpc::client::{ClientConf as RpcConf, ClientFactory, SyncClient};
 use curvine_rpc::ServerConf;
 use curvine_runtime::common::{LogConf, Utils};
 use log::info;
-use nix::ifaddrs::getifaddrs;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
+use std::net::IpAddr;
 use std::time::Duration;
 
 // Cluster configuration files.
@@ -386,25 +386,22 @@ impl ClusterConf {
     }
 
     /// Resolve the local IPv4 address bound to the named network interface
-    /// (e.g. `eth0`).
+    /// (e.g. `eth0` on Unix, the adapter friendly name on Windows).
     ///
-    /// Enumerates the host's interface addresses via `getifaddrs(3)` and returns
-    /// the first IPv4 address whose interface name matches `interface`. Returns
-    /// an error if the interface does not exist or has no IPv4 address assigned
-    /// (an IPv6-only interface yields no match).
+    /// Enumerates the host's interface addresses (via `getifaddrs(3)` on Unix,
+    /// `GetAdaptersAddresses` on Windows) and returns the first IPv4 address
+    /// whose interface name matches `interface`. Returns an error if the
+    /// interface does not exist or has no IPv4 address assigned (an IPv6-only
+    /// interface yields no match).
     pub fn interface_ipv4<T: AsRef<str>>(interface: T) -> CommonResult<String> {
         let interface = interface.as_ref();
-        let addrs = try_err!(getifaddrs());
+        let addrs = try_err!(if_addrs::get_if_addrs());
         for ifaddr in addrs {
-            if ifaddr.interface_name != interface {
+            if ifaddr.name != interface {
                 continue;
             }
-            // Only entries carrying an address are relevant; an interface can
-            // also surface broadcast/netmask-only rows we must skip.
-            if let Some(address) = ifaddr.address {
-                if let Some(sin) = address.as_sockaddr_in() {
-                    return Ok(sin.ip().to_string());
-                }
+            if let IpAddr::V4(v4) = ifaddr.ip() {
+                return Ok(v4.to_string());
             }
         }
         err_box!("no IPv4 address found on network interface '{}'", interface)


### PR DESCRIPTION
# Summary

Replace the Unix-only `nix::ifaddrs::getifaddrs` API with the cross-platform `if-addrs` crate when resolving the local IPv4 for `net_interface`. This fixes the Windows build failure of all non-FUSE modules (`curvine-config` failed to compile because `nix`'s `ifaddrs` module does not exist on Windows).

# Issue Describe / Design

**Root cause**

`ClusterConf::interface_ipv4` used `nix::ifaddrs::getifaddrs`. The `nix` crate exposes `ifaddrs` only on Unix; on Windows the crate compiles as an empty shell, so `crates/common/curvine-config` failed with:

```
error[E0432]: unresolved import `nix::ifaddrs`
  --> crates/common/curvine-config/src/cluster_conf.rs:29:10
```

Since `curvine-config` is a shared dependency of master/worker/server, every non-FUSE module failed to build on Windows.

**Fix approach**

- Add the `if-addrs` crate (0.13) as a workspace dependency. It wraps the same `getifaddrs(3)` syscall on Unix and `GetAdaptersAddresses` on Windows, so behavior is unchanged on Linux/macOS while Windows now compiles and works.
- Swap `nix` for `if-addrs` in `curvine-config` (it was the only `nix` usage there) and rewrite `interface_ipv4` with a single code path for all platforms.
- `Cargo.lock` is updated with the minimal `if-addrs` entries.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `Cargo.toml` | Add `if-addrs = "0.13"` to workspace dependencies | None |
| `crates/common/curvine-config/Cargo.toml` | `nix` -> `if-addrs` dependency | None (dependency-level swap) |
| `crates/common/curvine-config/src/cluster_conf.rs` | Rewrite `interface_ipv4` with `if_addrs::get_if_addrs()` | None on Unix; same semantics on Windows (adapter friendly name) |
| `Cargo.lock` | Minimal lock update for `if-addrs` | None |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo check -p curvine-server` (Windows MSVC, rustc 1.89) | PASS | Full master/worker/mds dependency chain |
| `cargo check` (default-members, Windows MSVC) | PASS | All non-FUSE modules compile; only pre-existing `curvine-fuse` Unix-only code remains out of scope |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None
