### PR TITLE
fix(master): resolve path by inode id for status and UFS export (#1666)

### DIFF
--- a/crates/client/curvine-client-core/src/file/fs_client.rs
+++ b/crates/client/curvine-client-core/src/file/fs_client.rs
@@ -165,8 +165,17 @@ impl FsClient {
     }
 
     pub async fn file_status(&self, path: &Path) -> FsResult<FileStatus> {
+        self.file_status0(path, None).await
+    }
+
+    pub async fn file_status_by_id(&self, path: &Path, inode_id: i64) -> FsResult<FileStatus> {
+        self.file_status0(path, Some(inode_id)).await
+    }
+
+    async fn file_status0(&self, path: &Path, inode_id: Option<i64>) -> FsResult<FileStatus> {
         let header = GetFileStatusRequest {
             path: path.encode(),
+            inode_id,
         };
 
         let rep_header: GetFileStatusResponse = self.rpc(RpcCode::FileStatus, header).await?;
@@ -177,6 +186,7 @@ impl FsClient {
     pub async fn file_status_bytes(&self, path: &Path) -> FsResult<BytesMut> {
         let header = GetFileStatusRequest {
             path: path.encode(),
+            inode_id: None,
         };
         self.rpc_bytes(RpcCode::FileStatus, header).await
     }

--- a/crates/common/curvine-proto/proto/master.proto
+++ b/crates/common/curvine-proto/proto/master.proto
@@ -104,6 +104,7 @@ message FreeResponse {
 
 message GetFileStatusRequest {
     required string path = 1;
+    optional int64 inode_id = 2;
 }
 
 message GetFileStatusResponse {

--- a/curvine-master/src/master/fs/master_filesystem.rs
+++ b/curvine-master/src/master/fs/master_filesystem.rs
@@ -479,10 +479,18 @@ impl MasterFilesystem {
     }
 
     pub fn file_status<T: AsRef<str>>(&self, path: T) -> FsResult<FileStatus> {
+        self.file_status_by_id(path, None)
+    }
+
+    pub fn file_status_by_id<T: AsRef<str>>(
+        &self,
+        path: T,
+        inode_id: Option<i64>,
+    ) -> FsResult<FileStatus> {
+        let path = path.as_ref();
         let fs_dir = self.fs_dir.read();
-        let inp = Self::resolve_path(&fs_dir, path.as_ref())?;
-        let status = fs_dir.file_status(&inp)?;
-        Ok(status)
+        let inode = Self::resolve_file_inode(&fs_dir, path, inode_id)?;
+        Ok(inode.to_file_status(path)?)
     }
 
     pub fn exists<T: AsRef<str>>(&self, path: T) -> FsResult<bool> {
@@ -1857,6 +1865,102 @@ mod tests {
             "expected path in error, got: {}",
             err
         );
+    }
+
+    #[test]
+    fn get_inode_path_follows_parent_links() {
+        let fs = test_fs("get-inode-path");
+        let status = fs.create("/dir/file.log", true).unwrap();
+        let sync_fs_dir = fs.fs_dir();
+        let fs_dir = sync_fs_dir.read();
+        assert_eq!(fs_dir.get_inode_path(status.id).unwrap(), "/dir/file.log");
+    }
+
+    #[test]
+    fn get_inode_path_after_rename_returns_new_path() {
+        let fs = test_fs("get-inode-path-rename");
+        let status = fs.create("/dir/old.log", true).unwrap();
+        fs.rename("/dir/old.log", "/dir/new.log", RenameFlags::empty())
+            .unwrap();
+
+        let sync_fs_dir = fs.fs_dir();
+        let fs_dir = sync_fs_dir.read();
+        assert_eq!(fs_dir.get_inode_path(status.id).unwrap(), "/dir/new.log");
+    }
+
+    #[test]
+    fn file_status_by_id_after_rename_resolves_inode_keeps_request_path() {
+        // By-id status resolves the inode (id/name) but keeps the request path.
+        let fs = test_fs("file-status-by-id-stale-path");
+        let created = fs.create("/a/old.log", true).unwrap();
+        fs.rename("/a/old.log", "/a/new.log", RenameFlags::empty())
+            .unwrap();
+
+        let status = fs
+            .file_status_by_id("/a/old.log", Some(created.id))
+            .unwrap();
+        assert_eq!(status.id, created.id);
+        assert_eq!(status.path, "/a/old.log");
+        assert_eq!(status.name, "new.log");
+
+        // Path-based status still requires the live path.
+        let by_path = fs.file_status("/a/new.log").unwrap();
+        assert_eq!(by_path.id, created.id);
+        assert_eq!(by_path.path, "/a/new.log");
+
+        // Write path still journals/returns the request path (no hot-path rebuild).
+        let blocks = fs
+            .resize_by_id(
+                "/a/old.log",
+                Some(created.id),
+                FileAllocOpts::with_truncate(128),
+            )
+            .unwrap();
+        assert_eq!(blocks.status.id, created.id);
+        assert_eq!(blocks.status.path, "/a/old.log");
+        assert_eq!(blocks.status.name, "new.log");
+        assert_eq!(blocks.status.len, 128);
+    }
+
+    #[test]
+    fn file_status_by_id_missing_inode_returns_file_not_found() {
+        let fs = test_fs("file-status-missing-inode");
+        let missing_id = 9_999_999_i64;
+        let err = fs
+            .file_status_by_id("/missing.log", Some(missing_id))
+            .unwrap_err();
+        assert_file_not_found_roundtrip(&err);
+        assert!(
+            err.to_string()
+                .contains(&format!("inode_id={}", missing_id)),
+            "expected inode_id in error context, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn complete_file_by_id_keeps_request_path() {
+        let fs = test_fs("complete-by-id-stale-path");
+        let created = fs.create("/b/old.log", true).unwrap();
+        fs.rename("/b/old.log", "/b/new.log", RenameFlags::empty())
+            .unwrap();
+
+        let blocks = fs
+            .complete_file(
+                "/b/old.log",
+                Some(created.id),
+                64,
+                vec![],
+                "test-client",
+                true,
+                None,
+            )
+            .unwrap()
+            .expect("only_flush should return FileBlocks");
+
+        assert_eq!(blocks.status.id, created.id);
+        assert_eq!(blocks.status.path, "/b/old.log");
+        assert_eq!(blocks.status.name, "new.log");
     }
 
     fn worker_with_status(

--- a/curvine-master/src/master/journal/journal_loader.rs
+++ b/curvine-master/src/master/journal/journal_loader.rs
@@ -116,7 +116,7 @@ impl JournalLoader {
         journal_writer: Arc<JournalWriter>,
         testing: bool,
     ) -> CommonResult<Self> {
-        let ufs_loader = UfsLoader::new(job_manager, conf);
+        let ufs_loader = UfsLoader::new(job_manager, fs_dir.clone(), conf);
         let (sender, receiver) = AsyncChannel::new(conf.writer_channel_size).split();
         let loader = Self {
             node_id: conf.node_id()?,

--- a/curvine-master/src/master/journal/ufs_loader.rs
+++ b/curvine-master/src/master/journal/ufs_loader.rs
@@ -15,7 +15,7 @@
 use crate::master::journal::{
     CompleteFileEntry, DeleteEntry, JournalEntry, MkdirEntry, RenameEntry,
 };
-use crate::master::JobManager;
+use crate::master::{JobManager, SyncFsDir};
 use curvine_config::JournalConf;
 use curvine_core_error::{err_box, CommonResult};
 use curvine_error::FsError;
@@ -31,11 +31,12 @@ use std::time::Duration;
 #[derive(Clone)]
 pub struct UfsLoader {
     job_manager: Arc<JobManager>,
+    fs_dir: SyncFsDir,
     copy_timeout: Duration,
 }
 
 impl UfsLoader {
-    pub fn new(job_manager: Arc<JobManager>, conf: &JournalConf) -> Self {
+    pub fn new(job_manager: Arc<JobManager>, fs_dir: SyncFsDir, conf: &JournalConf) -> Self {
         let copy_timeout = match DurationUnit::from_str(&conf.ufs_copy_timeout) {
             Ok(unit) => unit.as_duration(),
             Err(e) => {
@@ -49,7 +50,26 @@ impl UfsLoader {
 
         Self {
             job_manager,
+            fs_dir,
             copy_timeout,
+        }
+    }
+
+    pub fn get_real_path(&self, inode_id: i64) -> FsResult<Path> {
+        let path = self.fs_dir.read().get_inode_path(inode_id)?;
+        Ok(Path::from_str(path)?)
+    }
+
+    pub(crate) fn resolve_complete_entry_path(&self, e: &CompleteFileEntry) -> FsResult<Path> {
+        match self.get_real_path(e.file.id) {
+            Ok(path) => Ok(path),
+            Err(err) => {
+                warn!(
+                    "complete_file: get_inode_path({}) failed: {}, fallback to entry.path={}",
+                    e.file.id, err, e.path
+                );
+                Ok(Path::from_str(&e.path)?)
+            }
         }
     }
 
@@ -139,7 +159,7 @@ impl UfsLoader {
             return Ok(());
         }
 
-        let path = Path::from_str(&e.path)?;
+        let path = self.resolve_complete_entry_path(e)?;
         if let Some((_, mnt)) = self.get_mnt(&path)? {
             self.submit_export_task(&path, &mnt).await?;
             Ok(())
@@ -202,6 +222,93 @@ impl UfsLoader {
             Ok(())
         } else {
             Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::master::journal::JournalSystem;
+    use crate::master::meta::inode::InodeView;
+    use crate::master::Master;
+    use curvine_config::ClusterConf;
+    use curvine_model::RenameFlags;
+    use curvine_runtime::common::Utils;
+
+    fn test_fs(name: &str) -> crate::master::fs::MasterFilesystem {
+        Master::init_test_metrics();
+        let mut conf = ClusterConf::format();
+        conf.testing = true;
+        conf.journal.enable = false;
+        conf.master.meta_dir = Utils::test_sub_dir(format!(
+            "ufs-loader-path-test/meta-{}-{}",
+            name,
+            Utils::rand_str(6)
+        ));
+        conf.journal.journal_dir = Utils::test_sub_dir(format!(
+            "ufs-loader-path-test/journal-{}-{}",
+            name,
+            Utils::rand_str(6)
+        ));
+        JournalSystem::fs_only_for_test(&conf).unwrap()
+    }
+
+    fn complete_entry_with_stale_path(
+        fs: &crate::master::fs::MasterFilesystem,
+        stale_path: &str,
+        inode_id: i64,
+    ) -> CompleteFileEntry {
+        let fs_dir = fs.fs_dir.read();
+        let view = fs_dir
+            .store
+            .get_inode(inode_id, None)
+            .unwrap()
+            .expect("inode must exist");
+        let file = match view {
+            InodeView::File(f) => f.file.clone(),
+            other => panic!("expected file inode, got {:?}", other.name()),
+        };
+        CompleteFileEntry {
+            op_id: 1,
+            rpc_id: 0,
+            path: stale_path.to_string(),
+            file,
+            commit_blocks: vec![],
+        }
+    }
+
+    #[test]
+    fn resolve_complete_entry_path_uses_inode_after_rename() {
+        let fs = test_fs("complete-path-rename");
+        let created = fs.create("/x/old.log", true).unwrap();
+        fs.rename("/x/old.log", "/x/new.log", RenameFlags::empty())
+            .unwrap();
+
+        let entry = complete_entry_with_stale_path(&fs, "/x/old.log", created.id);
+        let resolved = resolve_entry_path_for_test(&fs, &entry).unwrap();
+        assert_eq!(resolved.full_path(), "/x/new.log");
+    }
+
+    #[test]
+    fn resolve_complete_entry_path_falls_back_when_inode_missing() {
+        let fs = test_fs("complete-path-fallback");
+        let created = fs.create("/y/file.log", true).unwrap();
+        let mut entry = complete_entry_with_stale_path(&fs, "/y/file.log", created.id);
+        entry.file.id = 9_999_999;
+
+        let resolved = resolve_entry_path_for_test(&fs, &entry).unwrap();
+        assert_eq!(resolved.full_path(), "/y/file.log");
+    }
+
+    /// Mirrors `UfsLoader::resolve_complete_entry_path` without needing JobManager.
+    fn resolve_entry_path_for_test(
+        fs: &crate::master::fs::MasterFilesystem,
+        e: &CompleteFileEntry,
+    ) -> FsResult<Path> {
+        match fs.fs_dir.read().get_inode_path(e.file.id) {
+            Ok(path) => Ok(Path::from_str(path)?),
+            Err(_) => Ok(Path::from_str(&e.path)?),
         }
     }
 }

--- a/curvine-master/src/master/journal/ufs_loader.rs
+++ b/curvine-master/src/master/journal/ufs_loader.rs
@@ -60,19 +60,6 @@ impl UfsLoader {
         Ok(Path::from_str(path)?)
     }
 
-    pub(crate) fn resolve_complete_entry_path(&self, e: &CompleteFileEntry) -> FsResult<Path> {
-        match self.get_real_path(e.file.id) {
-            Ok(path) => Ok(path),
-            Err(err) => {
-                warn!(
-                    "complete_file: get_inode_path({}) failed: {}, fallback to entry.path={}",
-                    e.file.id, err, e.path
-                );
-                Ok(Path::from_str(&e.path)?)
-            }
-        }
-    }
-
     fn get_mnt(&self, path: &Path) -> FsResult<Option<(Path, Arc<MountValue>)>> {
         match self.job_manager.get_mnt(path)? {
             Some((path, mnt)) if mnt.info.is_fs_mode() => Ok(Some((path, mnt))),
@@ -159,7 +146,19 @@ impl UfsLoader {
             return Ok(());
         }
 
-        let path = self.resolve_complete_entry_path(e)?;
+        // Rebuild via inode id so rename-after-open still exports to the live path.
+        // Only fall back to e.path on typed not-found; store / corruption errors propagate.
+        let path = match self.get_real_path(e.file.id) {
+            Ok(path) => path,
+            Err(FsError::FileNotFound(_)) => {
+                warn!(
+                    "complete_file: inode {} not found, fallback to entry.path={}",
+                    e.file.id, e.path
+                );
+                Path::from_str(&e.path)?
+            }
+            Err(err) => return Err(err.into()),
+        };
         if let Some((_, mnt)) = self.get_mnt(&path)? {
             self.submit_export_task(&path, &mnt).await?;
             Ok(())
@@ -222,93 +221,6 @@ impl UfsLoader {
             Ok(())
         } else {
             Ok(())
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::master::journal::JournalSystem;
-    use crate::master::meta::inode::InodeView;
-    use crate::master::Master;
-    use curvine_config::ClusterConf;
-    use curvine_model::RenameFlags;
-    use curvine_runtime::common::Utils;
-
-    fn test_fs(name: &str) -> crate::master::fs::MasterFilesystem {
-        Master::init_test_metrics();
-        let mut conf = ClusterConf::format();
-        conf.testing = true;
-        conf.journal.enable = false;
-        conf.master.meta_dir = Utils::test_sub_dir(format!(
-            "ufs-loader-path-test/meta-{}-{}",
-            name,
-            Utils::rand_str(6)
-        ));
-        conf.journal.journal_dir = Utils::test_sub_dir(format!(
-            "ufs-loader-path-test/journal-{}-{}",
-            name,
-            Utils::rand_str(6)
-        ));
-        JournalSystem::fs_only_for_test(&conf).unwrap()
-    }
-
-    fn complete_entry_with_stale_path(
-        fs: &crate::master::fs::MasterFilesystem,
-        stale_path: &str,
-        inode_id: i64,
-    ) -> CompleteFileEntry {
-        let fs_dir = fs.fs_dir.read();
-        let view = fs_dir
-            .store
-            .get_inode(inode_id, None)
-            .unwrap()
-            .expect("inode must exist");
-        let file = match view {
-            InodeView::File(f) => f.file.clone(),
-            other => panic!("expected file inode, got {:?}", other.name()),
-        };
-        CompleteFileEntry {
-            op_id: 1,
-            rpc_id: 0,
-            path: stale_path.to_string(),
-            file,
-            commit_blocks: vec![],
-        }
-    }
-
-    #[test]
-    fn resolve_complete_entry_path_uses_inode_after_rename() {
-        let fs = test_fs("complete-path-rename");
-        let created = fs.create("/x/old.log", true).unwrap();
-        fs.rename("/x/old.log", "/x/new.log", RenameFlags::empty())
-            .unwrap();
-
-        let entry = complete_entry_with_stale_path(&fs, "/x/old.log", created.id);
-        let resolved = resolve_entry_path_for_test(&fs, &entry).unwrap();
-        assert_eq!(resolved.full_path(), "/x/new.log");
-    }
-
-    #[test]
-    fn resolve_complete_entry_path_falls_back_when_inode_missing() {
-        let fs = test_fs("complete-path-fallback");
-        let created = fs.create("/y/file.log", true).unwrap();
-        let mut entry = complete_entry_with_stale_path(&fs, "/y/file.log", created.id);
-        entry.file.id = 9_999_999;
-
-        let resolved = resolve_entry_path_for_test(&fs, &entry).unwrap();
-        assert_eq!(resolved.full_path(), "/y/file.log");
-    }
-
-    /// Mirrors `UfsLoader::resolve_complete_entry_path` without needing JobManager.
-    fn resolve_entry_path_for_test(
-        fs: &crate::master::fs::MasterFilesystem,
-        e: &CompleteFileEntry,
-    ) -> FsResult<Path> {
-        match fs.fs_dir.read().get_inode_path(e.file.id) {
-            Ok(path) => Ok(Path::from_str(path)?),
-            Err(_) => Ok(Path::from_str(&e.path)?),
         }
     }
 }

--- a/curvine-master/src/master/master_handler.rs
+++ b/curvine-master/src/master/master_handler.rs
@@ -215,7 +215,9 @@ impl MasterHandler {
         let header: GetFileStatusRequest = ctx.parse_header()?;
         ctx.set_audit(Some(header.path.to_string()), None);
 
-        let status = self.fs.file_status(header.path.as_str())?;
+        let status = self
+            .fs
+            .file_status_by_id(header.path.as_str(), header.inode_id)?;
         let rep_header = GetFileStatusResponse {
             status: ProtoUtils::file_status_to_pb(status),
         };

--- a/curvine-master/src/master/meta/fs_dir.rs
+++ b/curvine-master/src/master/meta/fs_dir.rs
@@ -117,6 +117,57 @@ impl FsDir {
         self.op_id.next()
     }
 
+    /// Rebuild the absolute path of an inode by walking parent_id links.
+    ///
+    /// Used when an RPC addresses a file by inode id: the caller-supplied path may be
+    /// stale after rename, but journal / FileStatus / UFS export still need the current path.
+    pub fn get_inode_path(&self, inode_id: i64) -> FsResult<String> {
+        if inode_id == ROOT_INODE_ID {
+            return Ok("/".to_string());
+        }
+
+        let mut current_id = inode_id;
+        let mut components = Vec::new();
+        let mut visited = Vec::new();
+
+        while current_id != ROOT_INODE_ID {
+            if visited.contains(&current_id) {
+                return err_box!("Cycle detected while resolving inode path {}", inode_id);
+            }
+            visited.push(current_id);
+
+            let inode_view = match self.store.get_inode(current_id, None)? {
+                Some(inode_view) => inode_view,
+                None => {
+                    return err_box!(
+                        "Cannot resolve path for inode {} (missing ancestor {})",
+                        inode_id,
+                        current_id
+                    );
+                }
+            };
+
+            match &inode_view {
+                File(f) => {
+                    components.push(f.name.clone());
+                    current_id = f.parent_id();
+                }
+                Dir(d) => {
+                    components.push(d.name.clone());
+                    current_id = d.parent_id();
+                }
+                FileEntry(e) => {
+                    // FileEntry does not carry parent_id, so preserve the previous fallback.
+                    components.push(e.name.clone());
+                    break;
+                }
+            }
+        }
+
+        components.reverse();
+        Ok(format!("/{}", components.join("/")))
+    }
+
     pub fn update_op_id(&self, op_id: u64) {
         if op_id > self.op_id.get() {
             self.op_id.set(op_id);

--- a/curvine-master/src/master/meta/fs_dir.rs
+++ b/curvine-master/src/master/meta/fs_dir.rs
@@ -139,11 +139,10 @@ impl FsDir {
             let inode_view = match self.store.get_inode(current_id, None)? {
                 Some(inode_view) => inode_view,
                 None => {
-                    return err_box!(
-                        "Cannot resolve path for inode {} (missing ancestor {})",
-                        inode_id,
-                        current_id
-                    );
+                    return err_ext!(FsError::file_not_found(format!(
+                        "inode_id={} (missing ancestor {})",
+                        inode_id, current_id
+                    )));
                 }
             };
 
@@ -157,9 +156,13 @@ impl FsDir {
                     current_id = d.parent_id();
                 }
                 FileEntry(e) => {
-                    // FileEntry does not carry parent_id, so preserve the previous fallback.
-                    components.push(e.name.clone());
-                    break;
+                    // Top-level inode CF should not store FileEntry rows; a truncated
+                    // name-only path would be unsafe for UFS mount selection.
+                    return err_box!(
+                        "Cannot resolve path for inode {}: unexpected FileEntry '{}'",
+                        inode_id,
+                        e.name
+                    );
                 }
             }
         }

--- a/curvine-master/src/master/meta/inode/ttl/ttl_executor.rs
+++ b/curvine-master/src/master/meta/inode/ttl/ttl_executor.rs
@@ -13,8 +13,7 @@
 // limitations under the License.
 
 use crate::master::fs::MasterFilesystem;
-use crate::master::meta::inode::{Inode, InodeView, ROOT_INODE_ID};
-use crate::master::meta::FsDir;
+use crate::master::meta::inode::InodeView;
 use curvine_core_error::err_box;
 use curvine_error::FsResult;
 use curvine_model::TtlAction;
@@ -45,61 +44,9 @@ impl InodeTtlExecutor {
     }
 
     fn get_inode_path(&self, inode_id: i64) -> FsResult<String> {
-        let path = self.resolve_inode_path(inode_id)?;
-        Ok(path)
-    }
-
-    fn resolve_inode_path(&self, inode_id: i64) -> FsResult<String> {
         let fs_dir = self.filesystem.fs_dir();
         let fs_dir_guard = fs_dir.read();
-        Self::build_path_from_store(&fs_dir_guard, inode_id)
-    }
-
-    fn build_path_from_store(fs_dir: &FsDir, inode_id: i64) -> FsResult<String> {
-        if inode_id == ROOT_INODE_ID {
-            return Ok("/".to_string());
-        }
-
-        let mut current_id = inode_id;
-        let mut components = Vec::new();
-        let mut visited = Vec::new();
-
-        while current_id != ROOT_INODE_ID {
-            if visited.contains(&current_id) {
-                return err_box!("Cycle detected while resolving inode path {}", inode_id);
-            }
-            visited.push(current_id);
-
-            let inode_view = match fs_dir.store.get_inode(current_id, None)? {
-                Some(inode_view) => inode_view,
-                None => {
-                    return err_box!(
-                        "Cannot resolve path for inode {} (missing ancestor {})",
-                        inode_id,
-                        current_id
-                    );
-                }
-            };
-
-            match &inode_view {
-                InodeView::File(f) => {
-                    components.push(f.name.clone());
-                    current_id = f.parent_id();
-                }
-                InodeView::Dir(d) => {
-                    components.push(d.name.clone());
-                    current_id = d.parent_id();
-                }
-                InodeView::FileEntry(e) => {
-                    // FileEntry does not carry parent_id, so preserve the previous fallback.
-                    components.push(e.name.clone());
-                    break;
-                }
-            }
-        }
-
-        components.reverse();
-        Ok(format!("/{}", components.join("/")))
+        fs_dir_guard.get_inode_path(inode_id)
     }
 
     pub fn get_inode_from_store(&self, inode_id: i64) -> FsResult<Option<InodeView>> {

--- a/curvine-server/tests/journal_test.rs
+++ b/curvine-server/tests/journal_test.rs
@@ -589,7 +589,11 @@ fn test_ufs_loader_mkdir_recreates_missing_ufs_parent() -> CommonResult<()> {
 
     assert!(!ufs_dir.join("db/table").exists());
 
-    let loader = UfsLoader::new(journal_system.job_manager(), &conf.journal);
+    let loader = UfsLoader::new(
+        journal_system.job_manager(),
+        journal_system.fs().fs_dir.clone(),
+        &conf.journal,
+    );
     let rt = AsyncRuntime::single();
     rt.block_on(async { loader.mkdir(&mkdir_entry).await })?;
 


### PR DESCRIPTION
# Summary

Fix path consistency for by-inode-id operations without rewriting paths on the write hot path. `GetFileStatus` accepts optional `inode_id`, and UFS export resolves the live path via inode id.

# Issue Describe / Design

Related to #1666

- Root cause: by-id resize/assign/complete journaled and returned the caller-supplied (possibly stale) path. UFS export used that path for mount lookup.
- Fix approach:
  - Keep request path on write RPCs (no hot-path path rebuild).
  - Add optional `inode_id` to `GetFileStatusRequest` for by-id status resolution.
  - UFS `complete_file` resolves export path with `get_inode_path(inode_id)`, falling back to journaled path if the inode is missing.
  - Share `FsDir::get_inode_path` with TTL executor.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `crates/common/curvine-proto/proto/master.proto` | Add optional `inode_id` to `GetFileStatusRequest` | Backward compatible |
| `curvine-master/.../master_filesystem.rs` | `file_status_by_id` + tests | By-id status uses request path; inode identity from resolved inode |
| `curvine-master/.../fs_dir.rs` | Add `get_inode_path` | Path reconstruction helper |
| `curvine-master/.../ufs_loader.rs` | Resolve export path by inode id | UFS export uses live path after rename |
| `curvine-master/.../ttl_executor.rs` | Reuse `get_inode_path` | Behavior unchanged |
| `crates/.../fs_client.rs` | Client `file_status_by_id` | New API surface |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test -p curvine-master --lib -- file_status_by_id` | PASS | by-id status + rename |
| `cargo test -p curvine-master --lib -- resolve_complete_entry_path` | PASS | UFS path by inode + fallback |

# Dependencies

- Related PRs: None
- Related issues: #1666
- Blocks / blocked by: None