### PR TITLE
fix(master): keep expired directory TTL mtime during child delete (#1687)

### DIFF
--- a/curvine-master/src/master/meta/fs_dir.rs
+++ b/curvine-master/src/master/meta/fs_dir.rs
@@ -244,9 +244,11 @@ impl FsDir {
         // An already-expired parent TTL must keep its mtime: the checker can
         // delete child files first, and bumping mtime would un-expire the
         // directory for the rest of the same cleanup pass.
-        // `is_expired` can fail (e.g. FileEntry); never fail the delete.
-        if !matches!(parent.as_ref().is_expired(), Ok(true)) {
-            parent.update_mtime(mtime);
+        // Evaluate expiry at this delete's `mtime` so journal replay matches the
+        // leader. `expiration_ms` can fail (e.g. FileEntry); never fail the delete.
+        match parent.as_ref().expiration_ms() {
+            Ok(Some(exp)) if mtime > exp => {}
+            _ => parent.update_mtime(mtime),
         }
 
         let del_res = match child {

--- a/curvine-master/src/master/meta/fs_dir.rs
+++ b/curvine-master/src/master/meta/fs_dir.rs
@@ -240,8 +240,14 @@ impl FsDir {
         let child = target.as_ref();
         let child_name = inp.name();
 
-        // Handle different types of nodes
-        parent.update_mtime(mtime);
+        // Handle different types of nodes.
+        // An already-expired parent TTL must keep its mtime: the checker can
+        // delete child files first, and bumping mtime would un-expire the
+        // directory for the rest of the same cleanup pass.
+        // `is_expired` can fail (e.g. FileEntry); never fail the delete.
+        if !matches!(parent.as_ref().is_expired(), Ok(true)) {
+            parent.update_mtime(mtime);
+        }
 
         let del_res = match child {
             File(f) => {

--- a/curvine-server/tests/master_fs_test.rs
+++ b/curvine-server/tests/master_fs_test.rs
@@ -896,6 +896,57 @@ fn ttl_executor_deletes_nested_expired_inode() -> CommonResult<()> {
     Ok(())
 }
 
+// TTL delete must not refresh the parent directory mtime, otherwise a
+// directory with its own TTL is renewed after its child file is cleaned.
+#[test]
+fn ttl_executor_deletes_expired_directory_after_child_file() -> CommonResult<()> {
+    let _serial = master_fs_test_serial();
+    let fs = new_fs(true, "ttl-executor-dir-after-file");
+
+    let dir_opts = MkdirOptsBuilder::new()
+        .create_parent(true)
+        .ttl_ms(1)
+        .ttl_action(TtlAction::Delete)
+        .build();
+    let dir = fs.mkdir_with_opts("/ttl/expired-dir", dir_opts)?;
+
+    let file_opts = CreateFileOptsBuilder::new()
+        .ttl_ms(1)
+        .ttl_action(TtlAction::Delete)
+        .build();
+    let file = fs.create_with_opts(
+        "/ttl/expired-dir/file.log",
+        file_opts,
+        OpenFlags::new_create().set_overwrite(true),
+    )?;
+
+    std::thread::sleep(Duration::from_millis(10));
+    let executor = InodeTtlExecutor::with_managers(fs.clone());
+
+    let (file_processed, _) = executor.execute_by_id(file.id)?;
+    assert!(
+        file_processed,
+        "expired child file should be processed by TTL executor"
+    );
+    assert!(
+        fs.file_status("/ttl/expired-dir/file.log").is_err(),
+        "TTL delete should remove the child file"
+    );
+
+    let (dir_processed, inode) = executor.execute_by_id(dir.id)?;
+    assert!(
+        dir_processed,
+        "expired directory should still be processed after its child file is deleted"
+    );
+    assert_eq!(inode.id(), dir.id);
+    assert!(
+        fs.file_status("/ttl/expired-dir").is_err(),
+        "TTL delete should remove the expired directory, not only its child file"
+    );
+
+    Ok(())
+}
+
 // Regression: TTL path resolution must not re-acquire the fs_dir read lock while
 // already holding it. std::sync::RwLock is writer-preferring, so a reentrant read
 // deadlocks once a writer is queued. This reproduces the 2026-07-08 freeze shape:

--- a/curvine-server/tests/master_fs_test.rs
+++ b/curvine-server/tests/master_fs_test.rs
@@ -921,6 +921,7 @@ fn ttl_executor_deletes_expired_directory_after_child_file() -> CommonResult<()>
     )?;
 
     std::thread::sleep(Duration::from_millis(10));
+    let dir_mtime_before_child_delete = fs.file_status("/ttl/expired-dir")?.mtime;
     let executor = InodeTtlExecutor::with_managers(fs.clone());
 
     let (file_processed, _) = executor.execute_by_id(file.id)?;
@@ -931,6 +932,11 @@ fn ttl_executor_deletes_expired_directory_after_child_file() -> CommonResult<()>
     assert!(
         fs.file_status("/ttl/expired-dir/file.log").is_err(),
         "TTL delete should remove the child file"
+    );
+    assert_eq!(
+        fs.file_status("/ttl/expired-dir")?.mtime,
+        dir_mtime_before_child_delete,
+        "TTL child delete must not refresh an already-expired parent directory mtime"
     );
 
     let (dir_processed, inode) = executor.execute_by_id(dir.id)?;


### PR DESCRIPTION
# Summary

Stop TTL child deletes from refreshing an already-expired parent directory mtime, so directory TTL cleanup can still run in the same pass.

# Issue Describe / Design

Closes #1687

- Root cause: `unprotected_delete` always called `parent.update_mtime`. TTL expiration is `mtime + ttl_ms`, so deleting an expired child file un-expired the parent directory.
- Reproduction: create a TTL directory and a TTL child file, wait until both expire, execute the file then the directory; the file is removed and the directory remains.
- Fix: skip the parent mtime update when `is_expired()` is `Ok(true)`. Other results (not expired or error, e.g. FileEntry) still update mtime and never fail the delete.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-master/src/master/meta/fs_dir.rs` | Skip parent mtime bump when the parent is already TTL-expired | TTL directory cleanup can proceed after child file delete |
| `curvine-server/tests/master_fs_test.rs` | Add `ttl_executor_deletes_expired_directory_after_child_file` | Covers file-then-directory TTL execute order |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test -p curvine-server --test master_fs_test ttl_executor_deletes_expired_directory_after_child_file -- --exact` | PASS expected | Reproduces file cleaned / directory skipped before the fix |
| `cargo test -p curvine-server --test master_fs_test ttl_executor_deletes_nested_expired_inode -- --exact` | Existing | File-only nested TTL path unchanged |

# Dependencies

- Related PRs: None
- Related issues: #1687
- Blocks / blocked by: None

Made with [Cursor](https://cursor.com)